### PR TITLE
feat: resource limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # LiquidScript Change Log
 
+## Version 1.4.0
+
+**Features**
+
+- Resource limits. Optionally set limits on memory usage per template render to mitigate the impact of malicious templates.
+
 ## Version 1.3.1
 
 **Fixes**

--- a/docs/docs/guides/resource-limits.md
+++ b/docs/docs/guides/resource-limits.md
@@ -1,0 +1,126 @@
+# Resource Limits
+
+**_New in version 1.4.0_**
+
+For deployments where template authors are untrusted, you can set limits on some resources to avoid malicious templates from consuming too much memory or too many CPU cycles.
+
+```js
+import { Environment } from "liquidscript";
+
+const env = new Environment({
+  maxContextDepth: 30,
+  localNamespaceLimit: 3000,
+  loopIterationLimit: 1000,
+  outputStreamLimit: 15000,
+});
+
+const template = env.fromString(`
+{% for x in (1..1000000) %}
+{% for y in (1..1000000) %}
+  {{ x }},{{ y }}
+{% endfor %}
+{% endfor %}
+`);
+
+template.renderSync();
+// LoopIterationLimitError: loop iteration limit reached (<string>:2)
+```
+
+## Context Depth Limit
+
+The maximum number of times a render context can be copied or extended before a [`ContextDepthError`](../api/classes/ContextDepthError.md) is thrown. This helps us guard against recursive use of the `include` or `render` tags.
+
+The [`maxContextDepth`](../api/classes/Environment.md#maxcontextdepth) option defaults to `30`.
+
+```js
+import { Environment, ObjectLoader } from "liquidscript";
+
+const templates = {
+  foo: "{% render 'bar' %}",
+  bar: "{% render 'foo' %}",
+};
+
+const env = new Environment({
+  loader: new ObjectLoader(templates),
+  maxContextDepth: 30,
+});
+
+const template = env.fromString("{% render 'foo' %}");
+template.renderSync();
+// ContextDepthError: maximum context depth reached, possible recursive render (bar:1)
+```
+
+## Local Namespace Limit
+
+The maximum "size" of a render context local namespace. Rather than the number of bytes in memory a local namespace occupies, "size" is a non-specific indication of how much a template uses the local namespace when it is rendered, typically using the `assign` and `capture` tags.
+
+If the [`localNamespaceLimit`](../api/classes/Environment.md#localnamespacelimit) option is `undefined` or less than `0`, there is no limit. Otherwise a [`LocalNamespaceLimitError`](../api/classes/LocalNamespaceLimitError.md) is thrown when the namespace's size exceeds the limit.
+
+```js
+import { Environment } from "liquidscript";
+
+const env = new Environment({
+  localNamespaceLimit: 50, // Very low, for demonstration purposes.
+});
+
+const template = env.fromString(
+  '{% assign x = "Nunc est nulla, pellentesque ac dui id erat curae." %}'
+);
+
+template.renderSync();
+// LocalNamespaceLimitError: local namespace limit reached (<string>:1)
+```
+
+## Loop Iteration Limit
+
+The maximum number of loop iteration allowed before a [`LoopIterationLimitError`](../api/classes/LoopIterationLimitError.md) is thrown.
+
+If the [`loopIterationLimit`](../api/classes/Environment.md#loopiterationlimit) option is `undefined` or less than `0`, there is no soft limit.
+
+```js
+import { Environment } from "liquidscript";
+
+const env = new Environment({
+  loopIterationLimit: 999,
+});
+
+const template = env.fromString(`
+{% for x in (1..100) %}
+{% for y in (1..100) %}
+  {{ x }},{{ y }}
+{% endfor %}
+{% endfor %}
+`);
+
+template.renderSync();
+// LoopIterationLimitError: loop iteration limit reached (<string>:2)
+```
+
+Other built in tags that contribute to the loop iteration counter are `render`, `include` (when using their `{% render 'thing' for some.thing %}` syntax) and `tablerow`. If a partial template is rendered within a `for` loop, the loop counter is carried over to the render context of the partial template.
+
+## Output Stream Limit
+
+The maximum number of bytes that can be written to a template's output stream, per render, before an [`OutputStreamLimitError`](../api/classes/OutputStreamLimitError.md) is thrown.
+
+If the [`outputStreamLimit`](../api/classes/Environment.md#outputstreamlimit) option is `undefined` or less than `0`, there is no soft limit.
+
+```js
+import { Environment } from "liquidscript";
+
+const env = new Environment({
+  outputStreamLimit: 20, // Very low, for demonstration purposes.
+});
+
+const template = env.fromString(`
+{% if false %}
+this is never rendered, so will not contribute the the output byte counter
+{% endif %}
+Hello, {{ you }}! 
+`);
+
+template.renderSync({ you: "World" });
+// "\nHello, World!\n"
+
+template.renderSync({ you: "something longer that exceeds our limit" });
+// OutputStreamLimitError: output stream limit reached (<string>:5)
+```

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -132,6 +132,10 @@ const config = {
                 label: "Static Template Analysis",
                 to: "/guides/static-analysis",
               },
+              {
+                label: "Resource Limits",
+                to: "/guides/resource-limits",
+              },
             ],
           },
           {

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -36,6 +36,7 @@ const sidebars = {
         "guides/custom-tags",
         "guides/custom-loaders",
         "guides/static-analysis",
+        "guides/resource-limits",
       ],
     },
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liquidscript",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "author": "James",
   "license": "MIT",
   "homepage": "https://jg-rp.github.io/liquidscript/",

--- a/src/builtin/tags/capture.ts
+++ b/src/builtin/tags/capture.ts
@@ -2,7 +2,7 @@ import { BlockNode, Node, ChildNode } from "../../ast";
 import { RenderContext } from "../../context";
 import { Environment } from "../../environment";
 import { LiquidSyntaxError } from "../../errors";
-import { BufferedRenderStream, RenderStream } from "../../io/output_stream";
+import { RenderStream } from "../../io/output_stream";
 import { Tag } from "../../tag";
 import { Token, TokenStream, TOKEN_EOF, TOKEN_EXPRESSION } from "../../token";
 import { Markup } from "../drops/markup";
@@ -50,14 +50,17 @@ export class CaptureNode implements Node {
     else context.assign(this.name, buffer.toString());
   }
 
-  public async render(context: RenderContext): Promise<void> {
-    const buf = new BufferedRenderStream();
+  public async render(
+    context: RenderContext,
+    out: RenderStream
+  ): Promise<void> {
+    const buf = context.environment.renderStreamFactory(out);
     await this.block.render(context, buf);
     this.assign(context, buf);
   }
 
-  public renderSync(context: RenderContext): void {
-    const buf = new BufferedRenderStream();
+  public renderSync(context: RenderContext, out: RenderStream): void {
+    const buf = context.environment.renderStreamFactory(out);
     this.block.renderSync(context, buf);
     this.assign(context, buf);
   }

--- a/src/builtin/tags/case.ts
+++ b/src/builtin/tags/case.ts
@@ -3,7 +3,7 @@ import { RenderContext } from "../../context";
 import { Environment } from "../../environment";
 import { BooleanExpression, Literal } from "../../expression";
 import { parse } from "../../expressions/boolean/parse";
-import { BufferedRenderStream, RenderStream } from "../../io/output_stream";
+import { RenderStream } from "../../io/output_stream";
 import { Tag } from "../../tag";
 import {
   Token,
@@ -114,7 +114,7 @@ export class CaseNode implements Node {
     context: RenderContext,
     out: RenderStream
   ): Promise<void> {
-    const buf = new BufferedRenderStream();
+    const buf = context.environment.renderStreamFactory(out);
     let rendered = false;
 
     for (const _when of this.whens) {
@@ -137,7 +137,7 @@ export class CaseNode implements Node {
   }
 
   public renderSync(context: RenderContext, out: RenderStream): void {
-    const buf = new BufferedRenderStream();
+    const buf = context.environment.renderStreamFactory(out);
     let rendered = false;
 
     for (const _when of this.whens) {

--- a/src/builtin/tags/for.ts
+++ b/src/builtin/tags/for.ts
@@ -4,7 +4,7 @@ import { Environment } from "../../environment";
 import { BreakIteration, ContinueIteration } from "../../errors";
 import { LoopExpression } from "../../expression";
 import { parse } from "../../expressions/loop/parse";
-import { BufferedRenderStream, RenderStream } from "../../io/output_stream";
+import { RenderStream } from "../../io/output_stream";
 import { Tag } from "../../tag";
 import { Token, TOKEN_EXPRESSION, TOKEN_TAG, TokenStream } from "../../token";
 import { ForLoopDrop } from "../drops/forloop";
@@ -124,7 +124,9 @@ export class ForNode implements Node {
     // This intermediate buffer is used to detect and possibly
     // suppress blocks that, when rendered, contain only whitespace
     // Don't buffer the output stream if this.forceOutput is true.
-    const buf = this.forceOutput ? out : new BufferedRenderStream();
+    const buf = this.forceOutput
+      ? out
+      : context.environment.renderStreamFactory(out);
 
     if (length > 0) {
       const name = this.expression.name;
@@ -172,7 +174,9 @@ export class ForNode implements Node {
 
   public renderSync(context: RenderContext, out: RenderStream): void {
     const [it, length] = this.expression.evaluateSync(context);
-    const buf = this.forceOutput ? out : new BufferedRenderStream();
+    const buf = this.forceOutput
+      ? out
+      : context.environment.renderStreamFactory(out);
 
     if (length > 0) {
       const name = this.expression.name;

--- a/src/builtin/tags/for.ts
+++ b/src/builtin/tags/for.ts
@@ -137,6 +137,7 @@ export class ForNode implements Node {
           : context.environment.undefinedFactory("parentloop")
       );
 
+      context.raiseForLoopLimit(forloop.length);
       const namespace: ContextScope = { forloop: forloop };
       context.forLoops.push(forloop);
       try {
@@ -184,6 +185,7 @@ export class ForNode implements Node {
           : context.environment.undefinedFactory("parentloop")
       );
 
+      context.raiseForLoopLimit(forloop.length);
       const namespace: ContextScope = { forloop: forloop };
       context.forLoops.push(forloop);
       try {

--- a/src/builtin/tags/if.ts
+++ b/src/builtin/tags/if.ts
@@ -10,7 +10,7 @@ import {
 } from "../../token";
 import { BooleanExpression } from "../../expression";
 import { RenderContext } from "../../context";
-import { BufferedRenderStream, RenderStream } from "../../io/output_stream";
+import { RenderStream } from "../../io/output_stream";
 import { parse } from "../../expressions/boolean/parse";
 
 type ConditionalAlternative = {
@@ -112,7 +112,9 @@ export class IfNode implements Node {
     // This intermediate buffer is used to detect and possibly
     // suppress blocks that, when rendered, contain only whitespace.
     // Don't buffer the output stream if this.forceOutput is true.
-    const buf = this.forceOutput ? out : new BufferedRenderStream();
+    const buf = this.forceOutput
+      ? out
+      : context.environment.renderStreamFactory(out);
     let rendered = false;
 
     if (await this.condition.evaluate(context)) {
@@ -139,7 +141,9 @@ export class IfNode implements Node {
   }
 
   public renderSync(context: RenderContext, out: RenderStream): void {
-    const buf = this.forceOutput ? out : new BufferedRenderStream();
+    const buf = this.forceOutput
+      ? out
+      : context.environment.renderStreamFactory(out);
     let rendered = false;
 
     if (this.condition.evaluateSync(context)) {

--- a/src/builtin/tags/ifchanged.ts
+++ b/src/builtin/tags/ifchanged.ts
@@ -1,7 +1,7 @@
 import { BlockNode, Node, ChildNode } from "../../ast";
 import { RenderContext } from "../../context";
 import { Environment } from "../../environment";
-import { BufferedRenderStream, RenderStream } from "../../io/output_stream";
+import { RenderStream } from "../../io/output_stream";
 import { Tag } from "../../tag";
 import { Token, TokenStream } from "../../token";
 
@@ -32,7 +32,7 @@ export class IfChangedNode implements Node {
     context: RenderContext,
     out: RenderStream
   ): Promise<void> {
-    const buf = new BufferedRenderStream();
+    const buf = context.environment.renderStreamFactory(out);
     await this.block.render(context, buf);
     const buffered = buf.toString();
     const ifchanged = context.getRegister("ifchanged");
@@ -45,7 +45,7 @@ export class IfChangedNode implements Node {
   }
 
   public renderSync(context: RenderContext, out: RenderStream): void {
-    const buf = new BufferedRenderStream();
+    const buf = context.environment.renderStreamFactory(out);
     this.block.renderSync(context, buf);
     const buffered = buf.toString();
     const ifchanged = context.getRegister("ifchanged");

--- a/src/builtin/tags/render.ts
+++ b/src/builtin/tags/render.ts
@@ -146,7 +146,7 @@ export class RenderNode implements Node {
     }
 
     // Disable include tags in this context.
-    const ctx = context.copy(scope, ["include"]);
+    const ctx = context.copy(scope, ["include"], true);
 
     if (this.bindName) {
       const bindValue = await this.bindName.evaluate(context);
@@ -187,7 +187,7 @@ export class RenderNode implements Node {
     );
 
     // Disable include tags in this context.
-    const ctx = context.copy(scope, ["include"]);
+    const ctx = context.copy(scope, ["include"], true);
 
     if (this.bindName) {
       const bindValue = this.bindName.evaluateSync(context);

--- a/src/builtin/tags/tablerow.ts
+++ b/src/builtin/tags/tablerow.ts
@@ -10,7 +10,6 @@ import { isPrimitiveInteger, ContextScope } from "../../types";
 import { Tag } from "../../tag";
 import { Token, TokenStream, TOKEN_EXPRESSION } from "../../token";
 import { TableRowLoopDrop } from "../drops/tablerowloop";
-import { chainPop, chainPush } from "../../chain_object";
 
 const TAG_TABLEROW = "tablerow";
 const TAG_ENDTABLEROW = "endtablerow";
@@ -64,6 +63,7 @@ export class TableRowNode implements Node {
 
     const tablerowloop = new TableRowLoopDrop(name, it, length, cols as number);
     const namespace: ContextScope = { tablerowloop: tablerowloop };
+    context.raiseForLoopLimit(tablerowloop.length);
 
     await context.extend(namespace, async () => {
       out.write('<tr class="row1">\n');
@@ -100,6 +100,7 @@ export class TableRowNode implements Node {
 
     const tablerowloop = new TableRowLoopDrop(name, it, length, cols as number);
     const namespace: ContextScope = { tablerowloop: tablerowloop };
+    context.raiseForLoopLimit(tablerowloop.length);
 
     context.extendSync(namespace, () => {
       out.write('<tr class="row1">\n');

--- a/src/builtin/tags/unless.ts
+++ b/src/builtin/tags/unless.ts
@@ -3,7 +3,7 @@ import { RenderContext } from "../../context";
 import { Environment } from "../../environment";
 import { Expression } from "../../expression";
 import { parse } from "../../expressions/boolean/parse";
-import { BufferedRenderStream, RenderStream } from "../../io/output_stream";
+import { RenderStream } from "../../io/output_stream";
 import { Tag } from "../../tag";
 import {
   Token,
@@ -117,7 +117,9 @@ export class UnlessNode implements Node {
     context: RenderContext,
     out: RenderStream
   ): Promise<void> {
-    const buf = this.forceOutput ? out : new BufferedRenderStream();
+    const buf = this.forceOutput
+      ? out
+      : context.environment.renderStreamFactory(out);
     let rendered = false;
 
     if (!(await this.condition.evaluate(context))) {
@@ -144,7 +146,9 @@ export class UnlessNode implements Node {
   }
 
   public renderSync(context: RenderContext, out: RenderStream): void {
-    const buf = this.forceOutput ? out : new BufferedRenderStream();
+    const buf = this.forceOutput
+      ? out
+      : context.environment.renderStreamFactory(out);
     let rendered = false;
 
     if (!this.condition.evaluateSync(context)) {

--- a/src/context.ts
+++ b/src/context.ts
@@ -29,7 +29,6 @@ import {
   MaxLocalNamespaceLimitError,
   MaxLoopIterationLimitError,
 } from "./errors";
-import { RenderStream } from "./liquidscript";
 import { isNumberT } from "./number";
 import { Template } from "./template";
 import {

--- a/src/context.ts
+++ b/src/context.ts
@@ -332,7 +332,7 @@ export class RenderContext {
     scope: ContextScope,
     disabledTags: Iterable<string>
   ): RenderContext {
-    if (this.copyDepth > this.environment.maxContextDepth)
+    if (this.copyDepth + 1 > this.environment.maxContextDepth)
       throw new MaxContextDepthError(
         "maximum context depth reached, possible recursive render"
       );

--- a/src/context.ts
+++ b/src/context.ts
@@ -29,6 +29,7 @@ import {
   MaxLocalNamespaceLimitError,
   MaxLoopIterationLimitError,
 } from "./errors";
+import { RenderStream } from "./liquidscript";
 import { isNumberT } from "./number";
 import { Template } from "./template";
 import {

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -54,6 +54,37 @@ export type EnvironmentOptions = {
   maxContextDepth?: number;
 
   /**
+   * The maximum "size" of a render context local namespace. Rather than the
+   * number of bytes in memory a local namespace occupies, "size" is a non-
+   * specific indication of how much a template uses the local namespace when
+   * it is rendered, typically using the `assign` and `capture` tags.
+   *
+   * If `localNamespaceLimit` is `undefined` or less than 0, there is no limit.
+   * Otherwise a `LocalNamespaceLimitError`is thrown when the namespace's size
+   * exceeds the limit.
+   * @defaultValue undefined
+   */
+  localNamespaceLimit?: number;
+
+  /**
+   * The maximum number of loop iteration allowed before a `LoopIterationLimitError`
+   * is thrown.
+   *
+   * If `loopIterationLimit` is undefined or less than 0, there is no soft limit.
+   * @defaultValue undefined
+   */
+  loopIterationLimit?: number;
+
+  /**
+   * The maximum number of bytes that can be written to a template's output
+   * stream, per render, before an `OutputStreamLimitError` is thrown.
+   *
+   * If `outputStreamLimit` is undefined or less than 0, there is no soft limit.
+   * @defaultValue undefined
+   */
+  outputStreamLimit?: number;
+
+  /**
    * The sequence of characters indicating the start of a liquid output statement.
    * @defaultValue `{{`
    */
@@ -142,6 +173,9 @@ export class Environment {
   public globals: ContextScope;
   public loader: Loader;
   public maxContextDepth: number;
+  public localNamespaceLimit: number;
+  public loopIterationLimit: number;
+  public outputStreamLimit: number;
   readonly statementStartString: string;
   readonly statementEndString: string;
   public strictFilters: boolean;
@@ -175,6 +209,9 @@ export class Environment {
     globals,
     loader,
     maxContextDepth,
+    localNamespaceLimit,
+    loopIterationLimit,
+    outputStreamLimit,
     statementStartString,
     statementEndString,
     strictFilters,
@@ -187,6 +224,9 @@ export class Environment {
     this.globals = globals ?? {};
     this.loader = loader ?? new MapLoader();
     this.maxContextDepth = maxContextDepth ?? 30;
+    this.localNamespaceLimit = localNamespaceLimit ?? -1;
+    this.loopIterationLimit = loopIterationLimit ?? -1;
+    this.outputStreamLimit = outputStreamLimit ?? -1;
     this.statementStartString = statementStartString ?? "{{";
     this.statementEndString = statementEndString ?? "}}";
     this.strictFilters = strictFilters ?? true;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -154,6 +154,21 @@ export class LocalNamespaceLimitError extends LiquidError {
 }
 
 /**
+ * An error thrown when the loop iteration limit is reached.
+ */
+export class LoopIterationLimitError extends LiquidError {
+  constructor(public message: string, token: Token, templateName?: string) {
+    super(message, token);
+    Object.setPrototypeOf(this, LoopIterationLimitError.prototype);
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, LoopIterationLimitError);
+    }
+    this.name = "LoopIterationLimitError";
+    this.message = _message(message, token, templateName);
+  }
+}
+
+/**
  * An error thrown by the {@link StrictUndefined} class.
  */
 export class LiquidUndefinedError extends LiquidError {
@@ -318,6 +333,20 @@ export class MaxLocalNamespaceLimitError extends InternalLiquidError {
 
   public withToken(token: Token, templateName?: string): LiquidError {
     return new LocalNamespaceLimitError(this.message, token, templateName);
+  }
+}
+
+/**
+ * An error thrown when the loop iteration limit is reached.
+ */
+export class MaxLoopIterationLimitError extends InternalLiquidError {
+  constructor(public message: string) {
+    super(message);
+    Object.setPrototypeOf(this, MaxLoopIterationLimitError.prototype);
+  }
+
+  public withToken(token: Token, templateName?: string): LiquidError {
+    return new LoopIterationLimitError(this.message, token, templateName);
   }
 }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -169,6 +169,21 @@ export class LoopIterationLimitError extends LiquidError {
 }
 
 /**
+ * An error thrown when the output stream limit is reached.
+ */
+export class OutputStreamLimitError extends LiquidError {
+  constructor(public message: string, token: Token, templateName?: string) {
+    super(message, token);
+    Object.setPrototypeOf(this, OutputStreamLimitError.prototype);
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, OutputStreamLimitError);
+    }
+    this.name = "OutputStreamLimitError";
+    this.message = _message(message, token, templateName);
+  }
+}
+
+/**
  * An error thrown by the {@link StrictUndefined} class.
  */
 export class LiquidUndefinedError extends LiquidError {
@@ -347,6 +362,20 @@ export class MaxLoopIterationLimitError extends InternalLiquidError {
 
   public withToken(token: Token, templateName?: string): LiquidError {
     return new LoopIterationLimitError(this.message, token, templateName);
+  }
+}
+
+/**
+ * An error thrown when the output stream limit is reached.
+ */
+export class InternalOutputStreamLimitError extends InternalLiquidError {
+  constructor(public message: string) {
+    super(message);
+    Object.setPrototypeOf(this, InternalOutputStreamLimitError.prototype);
+  }
+
+  public withToken(token: Token, templateName?: string): LiquidError {
+    return new OutputStreamLimitError(this.message, token, templateName);
   }
 }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -139,6 +139,21 @@ export class ContextDepthError extends LiquidError {
 }
 
 /**
+ * An error thrown when a render context's local namespace limit is reached.
+ */
+export class LocalNamespaceLimitError extends LiquidError {
+  constructor(public message: string, token: Token, templateName?: string) {
+    super(message, token);
+    Object.setPrototypeOf(this, LocalNamespaceLimitError.prototype);
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, LocalNamespaceLimitError);
+    }
+    this.name = "LocalNamespaceLimitError";
+    this.message = _message(message, token, templateName);
+  }
+}
+
+/**
  * An error thrown by the {@link StrictUndefined} class.
  */
 export class LiquidUndefinedError extends LiquidError {
@@ -289,6 +304,20 @@ export class MaxContextDepthError extends InternalLiquidError {
 
   public withToken(token: Token, templateName?: string): LiquidError {
     return new ContextDepthError(this.message, token, templateName);
+  }
+}
+
+/**
+ * An error thrown when a render context's local namespace exceeds its limit.
+ */
+export class MaxLocalNamespaceLimitError extends InternalLiquidError {
+  constructor(public message: string) {
+    super(message);
+    Object.setPrototypeOf(this, MaxLocalNamespaceLimitError.prototype);
+  }
+
+  public withToken(token: Token, templateName?: string): LiquidError {
+    return new LocalNamespaceLimitError(this.message, token, templateName);
   }
 }
 

--- a/src/io/output_stream.ts
+++ b/src/io/output_stream.ts
@@ -1,3 +1,5 @@
+import { InternalOutputStreamLimitError } from "../errors";
+
 /**
  * An object to which a {@link Tag} can write its rendered content to.
  */
@@ -7,6 +9,8 @@ export interface RenderStream {
    * @param value - Template output text.
    */
   write(value: string): void;
+
+  size?: number;
 }
 
 /**
@@ -23,4 +27,41 @@ export class BufferedRenderStream implements RenderStream {
   toString(): string {
     return this.buffer.join("");
   }
+}
+
+/**
+ * A {@link RenderStream} implementation that buffers rendered content in
+ * memory and throws an OutputStreamLimitError if bytes written exceed its
+ * limit.
+ */
+export class LimitedRenderStream implements RenderStream {
+  public size: number = 0;
+  constructor(private limit: number, private buffer: string[] = []) {}
+
+  write(value: string): void {
+    if (value.length) {
+      this.size += _byteLength(value);
+      if (this.size > this.limit) {
+        throw new InternalOutputStreamLimitError("output stream limit reached");
+      }
+    }
+    this.buffer.push(value);
+  }
+
+  toString(): string {
+    return this.buffer.join("");
+  }
+}
+
+function _byteLength(value: string): number {
+  // From https://stackoverflow.com/questions/5515869/string-length-in-bytes-in-javascript
+  // returns the byte length of an utf8 string
+  let length: number = value.length;
+  for (let i = value.length - 1; i >= 0; i--) {
+    const code = value.charCodeAt(i);
+    if (code > 0x7f && code <= 0x7ff) length++;
+    else if (code > 0x7ff && code <= 0xffff) length += 2;
+    if (code >= 0xdc00 && code <= 0xdfff) i--; //trail surrogate
+  }
+  return length;
 }

--- a/tests/resource_limits.test.ts
+++ b/tests/resource_limits.test.ts
@@ -1,0 +1,65 @@
+import { ObjectLoader } from "../src/builtin/loaders";
+import { assignScore, RenderContext } from "../src/context";
+import { Environment } from "../src/environment";
+import { LocalNamespaceLimitError } from "../src/errors";
+import { Float, Integer } from "../src/number";
+import { Range } from "../src/range";
+
+describe("calculate assignment score", () => {
+  test("number", () => {
+    expect(assignScore(1)).toBe(1);
+  });
+  test("integer", () => {
+    expect(assignScore(new Integer(1))).toBeGreaterThan(1);
+  });
+  test("float", () => {
+    expect(assignScore(new Float(1.1))).toBeGreaterThan(1);
+  });
+  test("string", () => {
+    expect(assignScore("hello")).toBe(10);
+  });
+  test("array of strings", () => {
+    expect(assignScore(["a", "abc"])).toBe(8);
+  });
+  test("set of strings", () => {
+    expect(assignScore(new Set(["a", "abc"]))).toBe(8);
+  });
+  test("map of strings to numbers", () => {
+    const obj = new Map<string, number>([
+      ["a", 1],
+      ["b", 2],
+    ]);
+    expect(assignScore(obj)).toBe(6);
+  });
+  test("iterable", () => {
+    const obj = new Range(0, 3);
+    expect(assignScore(obj)).toBe(4);
+  });
+});
+
+describe("local namespace limit", () => {
+  test("set a limit", () => {
+    const env = new Environment({ localNamespaceLimit: 10 });
+    const template = env.fromString("{% assign greeting = 'hello' %}");
+    const ctx = new RenderContext(env, {});
+    template.renderWithContextSync(ctx, env.renderStreamFactory());
+    expect(ctx.localsScore).toBe(10);
+    env.localNamespaceLimit = 9;
+    expect(() => template.renderSync()).toThrow(LocalNamespaceLimitError);
+  });
+
+  test("limit is carried through to copied render context objects", () => {
+    const loader = new ObjectLoader({
+      foo: "{% assign bar = 'goodbye' %}",
+    });
+    const env = new Environment({ loader: loader, localNamespaceLimit: 24 });
+    const template = env.fromString(
+      "{% assign greeting = 'hello' %}{% render 'foo' %}"
+    );
+    const ctx = new RenderContext(env, {});
+    template.renderWithContextSync(ctx, env.renderStreamFactory());
+    expect(ctx.localsScore).toBe(10);
+    env.localNamespaceLimit = 23;
+    expect(() => template.renderSync()).toThrow(LocalNamespaceLimitError);
+  });
+});

--- a/tests/resource_limits.test.ts
+++ b/tests/resource_limits.test.ts
@@ -5,6 +5,7 @@ import {
   ContextDepthError,
   LocalNamespaceLimitError,
   LoopIterationLimitError,
+  OutputStreamLimitError,
 } from "../src/errors";
 import { Float, Integer } from "../src/number";
 import { Range } from "../src/range";
@@ -244,6 +245,41 @@ describe("loop iteration limit", () => {
     expect(() => template.renderSync()).toThrowError(LoopIterationLimitError);
     expect(async () => await template.render()).rejects.toThrowError(
       LoopIterationLimitError
+    );
+  });
+});
+
+describe("output stream limit", () => {
+  test("set output stream limit with constructor", async () => {
+    const env = new Environment({ outputStreamLimit: 5 });
+    let template = env.fromString(
+      "{% if false %}some literal that is longer then the limit{% endif %}hello"
+    );
+    expect(template.renderSync()).toBe("hello");
+
+    template = env.fromString(
+      "{% if true %}some literal that is longer then the limit{% endif %}hello"
+    );
+    expect(() => template.renderSync()).toThrowError(OutputStreamLimitError);
+    expect(async () => await template.render()).rejects.toThrowError(
+      OutputStreamLimitError
+    );
+  });
+
+  test("set output stream limit after construction", async () => {
+    const env = new Environment();
+    env.outputStreamLimit = 5;
+    let template = env.fromString(
+      "{% if false %}some literal that is longer then the limit{% endif %}hello"
+    );
+    expect(template.renderSync()).toBe("hello");
+
+    template = env.fromString(
+      "{% if true %}some literal that is longer then the limit{% endif %}hello"
+    );
+    expect(() => template.renderSync()).toThrowError(OutputStreamLimitError);
+    expect(async () => await template.render()).rejects.toThrowError(
+      OutputStreamLimitError
     );
   });
 });


### PR DESCRIPTION
Limit the resources a malicious template can consume by setting limits on a LiquidScript [`Environment`](https://jg-rp.github.io/liquidscript/introduction/getting-started#environment).