### PR TITLE
Inline `if` expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**
 
 - Allow customization of local namespace limits by overriding `RenderContext.assignScore`. See [#5](https://github.com/jg-rp/liquidscript/issues/5).
+- New `macro` and `call` tags. Define parameterized Liquid snippets with the `macro` tag and call them using the `call` tag. `macro` and `call` are optional extra tags that need to be explicitly registered with a `liquidscript.Environment`.
 
 ## Version 1.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Allow customization of local namespace limits by overriding `RenderContext.assignScore`. See [#5](https://github.com/jg-rp/liquidscript/issues/5).
 - New `macro` and `call` tags. Define parameterized Liquid snippets with the `macro` tag and call them using the `call` tag. `macro` and `call` are optional extra tags that need to be explicitly registered with a `liquidscript.Environment`.
+- New drop-in replacements for the standard output statement (`{{ output }}`), `assign` tag and `echo` tag that support inline conditional expressions, optionally including a logical `not` operator and grouping terms with parentheses.
 
 ## Version 1.6.0
 

--- a/src/builtin/tags/assign.ts
+++ b/src/builtin/tags/assign.ts
@@ -17,6 +17,10 @@ export class AssignTag implements Tag {
   readonly name: string = "assign";
   protected nodeClass = AssignNode;
 
+  protected parseExpression(value: string, startIndex: number): Expression {
+    return parse(value, startIndex);
+  }
+
   public parse(stream: TokenStream): Node {
     const token = stream.next();
     stream.expect(TOKEN_EXPRESSION);
@@ -29,7 +33,11 @@ export class AssignTag implements Tag {
       );
 
     const [, name, expr] = match;
-    return new this.nodeClass(token, name, parse(expr));
+    return new this.nodeClass(
+      token,
+      name,
+      this.parseExpression(expr, stream.current.index)
+    );
   }
 }
 

--- a/src/builtin/tags/cycle.ts
+++ b/src/builtin/tags/cycle.ts
@@ -65,8 +65,10 @@ export class CycleNode implements Node {
       key = args.toString();
     } else if (isUndefined(groupName)) {
       key = UndefinedCycleGroup;
+    } else if (groupName === null) {
+      key = "";
     } else {
-      key = groupName?.toString() || "";
+      key = groupName.toString();
     }
 
     let index = <number>(cycles.has(key) ? cycles.get(key) : 0);

--- a/src/builtin/tags/echo.ts
+++ b/src/builtin/tags/echo.ts
@@ -3,12 +3,16 @@ import { Tag } from "../../tag";
 import { TokenStream, TOKEN_EOF, TOKEN_EXPRESSION } from "../../token";
 import { parse } from "../../expressions/filtered/parse";
 import { OutputStatementNode } from "./statement";
-import { NIL } from "../../expression";
+import { Expression, NIL } from "../../expression";
 
 export class EchoTag implements Tag {
   readonly block = false;
   readonly name: string = "echo";
   protected nodeClass = EchoNode;
+
+  protected parseExpression(value: string, startIndex: number): Expression {
+    return parse(value, startIndex);
+  }
 
   parse(stream: TokenStream): Node {
     const token = stream.next();
@@ -19,7 +23,7 @@ export class EchoTag implements Tag {
     stream.expect(TOKEN_EXPRESSION);
     return new this.nodeClass(
       token,
-      parse(stream.current.value, stream.current.index)
+      this.parseExpression(stream.current.value, stream.current.index)
     );
   }
 }

--- a/src/builtin/tags/statement.ts
+++ b/src/builtin/tags/statement.ts
@@ -14,7 +14,7 @@ export class OutputStatement implements Tag {
   readonly name: string = "statement";
   protected nodeClass = OutputStatementNode;
 
-  parse(stream: TokenStream): Node {
+  public parse(stream: TokenStream): Node {
     return new this.nodeClass(
       stream.current,
       parse(stream.current.value, stream.current.index)

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -493,11 +493,11 @@ export class FilteredExpression implements Expression {
 
   public children(): Expression[] {
     const _children = [this.expression];
-    for (const fltr of this.filters) {
-      for (const arg of fltr.args) {
+    for (const filter of this.filters) {
+      for (const arg of filter.args) {
         _children.push(arg);
       }
-      for (const arg of fltr.kwargs.values()) {
+      for (const arg of filter.kwargs.values()) {
         _children.push(arg);
       }
     }
@@ -587,11 +587,11 @@ export class ConditionalExpression extends FilteredExpression {
       _children.push(this.alternative);
     }
 
-    for (const fltr of this.filters) {
-      for (const arg of fltr.args) {
+    for (const filter of this.filters) {
+      for (const arg of filter.args) {
         _children.push(arg);
       }
-      for (const arg of fltr.kwargs.values()) {
+      for (const arg of filter.kwargs.values()) {
         _children.push(arg);
       }
     }

--- a/src/expressions/arguments/parse.ts
+++ b/src/expressions/arguments/parse.ts
@@ -1,6 +1,6 @@
 import { LiquidSyntaxError } from "../../errors";
 import { Expression, NIL } from "../../expression";
-import { parseStringLiteral, parseUnchainedIdentifier } from "../common";
+import { parseUnchainedIdentifier } from "../common";
 import { parseObject } from "../filtered/parse";
 import {
   ExpressionTokenStream,

--- a/src/expressions/boolean_not/parse.ts
+++ b/src/expressions/boolean_not/parse.ts
@@ -39,11 +39,12 @@ import {
   TOKEN_NOT,
   TOKEN_NULL,
   TOKEN_OR,
+  TOKEN_RANGE_LPAREN,
   TOKEN_RPAREN,
   TOKEN_STRING,
   TOKEN_TRUE,
 } from "../tokens";
-import { tokenize, TOKEN_RANGE_LPAREN } from "./lex";
+import { tokenize } from "./lex";
 
 const PRECEDENCE_LOWEST = 1;
 const PRECEDENCE_LOGICAL_RIGHT = 3;
@@ -172,8 +173,8 @@ TOKEN_MAP.set(TOKEN_LPAREN, parse_grouped_expression);
  * Parse an expression that follows Liquid `if` tag semantics plus a
  * logical `not` operator and grouping with parentheses.
  */
-export function parse(expr: string, lineNumber: number = 1): BooleanExpression {
-  const stream = new ExpressionTokenStream(tokenize(expr, lineNumber));
+export function parse(expr: string, startIndex: number = 0): BooleanExpression {
+  const stream = new ExpressionTokenStream(tokenize(expr, startIndex));
   const booleanExpression = new BooleanExpression(parseObject(stream));
   if (stream.peek.kind === TOKEN_RPAREN) {
     throw new LiquidSyntaxError("unmatched ')'", stream.peek);

--- a/src/expressions/conditional/index.ts
+++ b/src/expressions/conditional/index.ts
@@ -1,0 +1,2 @@
+export * from "./lex";
+export * from "./parse";

--- a/src/expressions/conditional/lex.ts
+++ b/src/expressions/conditional/lex.ts
@@ -419,7 +419,7 @@ export function makeTokenizer(re: RegExp, keywords: Set<string>): Tokenizer {
         );
       else if (isDoublePipeMatch(groups))
         yield new Token(
-          TOKEN_PIPE,
+          TOKEN_DPIPE,
           groups.TOKEN_DPIPE,
           <number>match.index + startIndex,
           source

--- a/src/expressions/conditional/parse.ts
+++ b/src/expressions/conditional/parse.ts
@@ -2,6 +2,7 @@ import {
   BooleanExpression,
   ConditionalExpression,
   Expression,
+  ExpressionFilter,
   FALSE,
   FilteredExpression,
   NIL,
@@ -36,6 +37,7 @@ function splitAtFirst(
       buf.push(token);
     }
     yield buf;
+    yield [];
   }
   return _splitAtFirst;
 }
@@ -77,15 +79,13 @@ export function parse(
     _conditionalTokens[Symbol.iterator]()
   );
 
-  let condition: BooleanExpression;
+  let condition: Expression;
   if (conditionalTokens.length === 0) {
     // An `if` with nothing after it.
-    condition = new BooleanExpression(FALSE);
+    condition = FALSE;
   } else {
-    condition = new BooleanExpression(
-      parseBooleanObject(
-        new ExpressionTokenStream(conditionalTokens[Symbol.iterator]())
-      )
+    condition = parseBooleanObject(
+      new ExpressionTokenStream(conditionalTokens[Symbol.iterator]())
     );
   }
 
@@ -96,9 +96,14 @@ export function parse(
     alternative = parseStandardFiltered(alternativeTokens[Symbol.iterator]());
   }
 
-  const tailFilters = Array.from(
-    splitAtPipe(tailFilterTokens[Symbol.iterator]())
-  ).map(parseFilter);
+  let tailFilters: ExpressionFilter[];
+  if (tailFilterTokens.length > 0) {
+    tailFilters = Array.from(
+      splitAtPipe(tailFilterTokens[Symbol.iterator]())
+    ).map(parseFilter);
+  } else {
+    tailFilters = [];
+  }
 
   return new ConditionalExpression(_expr, tailFilters, condition, alternative);
 }
@@ -123,15 +128,13 @@ export function parseWithParens(
     _conditionalTokens[Symbol.iterator]()
   );
 
-  let condition: BooleanExpression;
+  let condition: Expression;
   if (conditionalTokens.length === 0) {
     // An `if` with nothing after it.
-    condition = new BooleanExpression(FALSE);
+    condition = FALSE;
   } else {
-    condition = new BooleanExpression(
-      parseBooleanObjectWithParens(
-        new ExpressionTokenStream(conditionalTokens[Symbol.iterator]())
-      )
+    condition = parseBooleanObjectWithParens(
+      new ExpressionTokenStream(conditionalTokens[Symbol.iterator]())
     );
   }
 
@@ -142,9 +145,14 @@ export function parseWithParens(
     alternative = parseStandardFiltered(alternativeTokens[Symbol.iterator]());
   }
 
-  const tailFilters = Array.from(
-    splitAtPipe(tailFilterTokens[Symbol.iterator]())
-  ).map(parseFilter);
+  let tailFilters: ExpressionFilter[];
+  if (tailFilterTokens.length > 0) {
+    tailFilters = Array.from(
+      splitAtPipe(tailFilterTokens[Symbol.iterator]())
+    ).map(parseFilter);
+  } else {
+    tailFilters = [];
+  }
 
   return new ConditionalExpression(_expr, tailFilters, condition, alternative);
 }

--- a/src/expressions/conditional/parse.ts
+++ b/src/expressions/conditional/parse.ts
@@ -1,0 +1,150 @@
+import {
+  BooleanExpression,
+  ConditionalExpression,
+  Expression,
+  FALSE,
+  FilteredExpression,
+  NIL,
+} from "../../expression";
+import { Token } from "../../token";
+import {
+  ExpressionTokenStream,
+  TOKEN_DPIPE,
+  TOKEN_ELSE,
+  TOKEN_IF,
+  TOKEN_PIPE,
+} from "../tokens";
+import { tokenize, tokenizeWithParens } from "./lex";
+import {
+  parseFilter,
+  parseFromTokens as parseStandardFiltered,
+} from "../filtered/parse";
+import { parseObject as parseBooleanObject } from "../boolean";
+import { parseObject as parseBooleanObjectWithParens } from "../boolean_not";
+
+function splitAtFirst(
+  kind: string
+): (tokens: IterableIterator<Token>) => Generator<Token[]> {
+  function* _splitAtFirst(tokens: IterableIterator<Token>): Generator<Token[]> {
+    const buf: Token[] = [];
+    for (const token of tokens) {
+      if (token.kind === kind) {
+        yield buf;
+        yield Array.from(tokens);
+        return;
+      }
+      buf.push(token);
+    }
+    yield buf;
+  }
+  return _splitAtFirst;
+}
+
+function* splitAtPipe(tokens: IterableIterator<Token>): Generator<Token[]> {
+  let buf: Token[] = [];
+  for (const token of tokens) {
+    if (token.kind === TOKEN_PIPE) {
+      yield buf;
+      buf = [];
+    } else {
+      buf.push(token);
+    }
+  }
+  yield buf;
+}
+
+const splitAtFirstDoublePipe = splitAtFirst(TOKEN_DPIPE);
+const splitAtFirstIf = splitAtFirst(TOKEN_IF);
+const splitAtFirstElse = splitAtFirst(TOKEN_ELSE);
+
+export function parse(
+  expr: string,
+  startIndex: number = 0
+): FilteredExpression {
+  const tokens = tokenize(expr, startIndex);
+  const [standardTokens, extendedTokens] = splitAtFirstIf(tokens);
+  const _expr = parseStandardFiltered(standardTokens[Symbol.iterator]());
+
+  if (extendedTokens.length === 0) {
+    return _expr;
+  }
+
+  const [_conditionalTokens, tailFilterTokens] = splitAtFirstDoublePipe(
+    extendedTokens[Symbol.iterator]()
+  );
+
+  const [conditionalTokens, alternativeTokens] = splitAtFirstElse(
+    _conditionalTokens[Symbol.iterator]()
+  );
+
+  let condition: BooleanExpression;
+  if (conditionalTokens.length === 0) {
+    // An `if` with nothing after it.
+    condition = new BooleanExpression(FALSE);
+  } else {
+    condition = new BooleanExpression(
+      parseBooleanObject(
+        new ExpressionTokenStream(conditionalTokens[Symbol.iterator]())
+      )
+    );
+  }
+
+  let alternative: Expression;
+  if (alternativeTokens.length === 0) {
+    alternative = NIL;
+  } else {
+    alternative = parseStandardFiltered(alternativeTokens[Symbol.iterator]());
+  }
+
+  const tailFilters = Array.from(
+    splitAtPipe(tailFilterTokens[Symbol.iterator]())
+  ).map(parseFilter);
+
+  return new ConditionalExpression(_expr, tailFilters, condition, alternative);
+}
+
+export function parseWithParens(
+  expr: string,
+  startIndex: number = 0
+): FilteredExpression {
+  const tokens = tokenizeWithParens(expr, startIndex);
+  const [standardTokens, extendedTokens] = splitAtFirstIf(tokens);
+  const _expr = parseStandardFiltered(standardTokens[Symbol.iterator]());
+
+  if (extendedTokens.length === 0) {
+    return _expr;
+  }
+
+  const [_conditionalTokens, tailFilterTokens] = splitAtFirstDoublePipe(
+    extendedTokens[Symbol.iterator]()
+  );
+
+  const [conditionalTokens, alternativeTokens] = splitAtFirstElse(
+    _conditionalTokens[Symbol.iterator]()
+  );
+
+  let condition: BooleanExpression;
+  if (conditionalTokens.length === 0) {
+    // An `if` with nothing after it.
+    condition = new BooleanExpression(FALSE);
+  } else {
+    condition = new BooleanExpression(
+      parseBooleanObjectWithParens(
+        new ExpressionTokenStream(conditionalTokens[Symbol.iterator]())
+      )
+    );
+  }
+
+  let alternative: Expression;
+  if (alternativeTokens.length === 0) {
+    alternative = NIL;
+  } else {
+    alternative = parseStandardFiltered(alternativeTokens[Symbol.iterator]());
+  }
+
+  const tailFilters = Array.from(
+    splitAtPipe(tailFilterTokens[Symbol.iterator]())
+  ).map(parseFilter);
+
+  return new ConditionalExpression(_expr, tailFilters, condition, alternative);
+}

--- a/src/expressions/filtered/parse.ts
+++ b/src/expressions/filtered/parse.ts
@@ -62,11 +62,6 @@ export function parseObject(stream: ExpressionTokenStream): Expression {
 
 TOKEN_MAP.set(TOKEN_LPAREN, makeParseRange(parseObject));
 
-/**
- *
- * @param tokens
- * @returns
- */
 function* splitAtFirstPipe(
   tokens: IterableIterator<Token>
 ): Generator<Token[]> {
@@ -95,7 +90,7 @@ function* splitAtPipe(tokens: IterableIterator<Token>): Generator<Token[]> {
   yield buf;
 }
 
-function parseFilter(tokens: Token[]): ExpressionFilter {
+export function parseFilter(tokens: Token[]): ExpressionFilter {
   const stream = new ExpressionTokenStream(tokens.values());
 
   stream.expect(TOKEN_IDENT);
@@ -135,11 +130,9 @@ function parseFilter(tokens: Token[]): ExpressionFilter {
   return new ExpressionFilter(name, args, kwargs);
 }
 
-export function parse(
-  expr: string,
-  lineNumber: number = 1
+export function parseFromTokens(
+  tokens: IterableIterator<Token>
 ): FilteredExpression {
-  const tokens = tokenize(expr, lineNumber);
   const parts = Array.from(splitAtFirstPipe(tokens));
 
   if (parts.length === 1) {
@@ -152,4 +145,11 @@ export function parse(
     parseObject(new ExpressionTokenStream(parts[0].values())),
     Array.from(splitAtPipe(parts[1].values())).map(parseFilter)
   );
+}
+
+export function parse(
+  expr: string,
+  startIndex: number = 0
+): FilteredExpression {
+  return parseFromTokens(tokenize(expr, startIndex));
 }

--- a/src/expressions/index.ts
+++ b/src/expressions/index.ts
@@ -7,3 +7,4 @@ export * as loop from "./loop";
 export * as boolean_not from "./boolean_not";
 export * as arguments from "./arguments";
 export * as standard from "./standard";
+export * as conditional from "./conditional";

--- a/src/expressions/tokens.ts
+++ b/src/expressions/tokens.ts
@@ -17,6 +17,7 @@ export const TOKEN_FLOAT = "TOKEN_FLOAT";
 export const TOKEN_LPAREN = "TOKEN_LPAREN";
 export const TOKEN_RPAREN = "TOKEN_RPAREN";
 export const TOKEN_RANGE = "TOKEN_RANGE";
+export const TOKEN_RANGE_LPAREN = "TOKEN_RANGE_LPAREN";
 export const TOKEN_STRING = "TOKEN_STRING";
 export const TOKEN_EOF = "TOKEN_EOF";
 export const TOKEN_NEWLINE = "TOKEN_NEWLINE";
@@ -36,12 +37,17 @@ export const TOKEN_REVERSED = "reversed";
 export const TOKEN_CONTINUE = "continue";
 export const TOKEN_COLS = "cols";
 
+export const TOKEN_DPIPE = "TOKEN_DPIPE";
 export const TOKEN_PIPE = "TOKEN_PIPE";
 export const TOKEN_COLON = "TOKEN_COLON";
 export const TOKEN_COMMA = "TOKEN_COMMA";
 
 // Assignment as used by `assign` and `capture` tags.
 export const TOKEN_ASSIGN = "TOKEN_ASSIGN";
+
+// Inline conditional tokens
+export const TOKEN_IF = "if";
+export const TOKEN_ELSE = "else";
 
 // Logical operators
 export const TOKEN_AND = "and";

--- a/src/extra/tags/if_expressions.ts
+++ b/src/extra/tags/if_expressions.ts
@@ -1,0 +1,80 @@
+import { AssignTag, EchoTag, OutputStatement } from "../../builtin/tags";
+import { Node } from "../../ast";
+import { TokenStream } from "../../token";
+import {
+  parse as parseConditionalExpression,
+  parseWithParens as parseConditionalExpressionWithParens,
+} from "../../expressions/conditional/parse";
+import { Expression } from "../../expression";
+
+/**
+ * A drop-in replacement for the standard output statement that supports
+ * inline `if` expressions.
+ */
+export class ConditionalOutputStatement extends OutputStatement {
+  public parse(stream: TokenStream): Node {
+    return new this.nodeClass(
+      stream.current,
+      parseConditionalExpression(stream.current.value, stream.current.index)
+    );
+  }
+}
+
+/**
+ * A drop-in replacement for the standard assign tag that supports
+ * inline `if` expressions.
+ */
+export class ConditionalAssignTag extends AssignTag {
+  protected parseExpression(value: string, startIndex: number): Expression {
+    return parseConditionalExpression(value, startIndex);
+  }
+}
+
+/**
+ * A drop-in replacement for the standard echo tag that supports
+ * inline `if` expressions.
+ */
+export class ConditionalEchoTag extends EchoTag {
+  protected parseExpression(value: string, startIndex: number): Expression {
+    return parseConditionalExpression(value, startIndex);
+  }
+}
+
+/**
+ * A drop-in replacement for the standard output statement that supports
+ * inline `if` expressions with a logical `not` operator and grouping
+ * terms with parentheses.
+ */
+export class ConditionalOutputStatementWithParens extends OutputStatement {
+  public parse(stream: TokenStream): Node {
+    return new this.nodeClass(
+      stream.current,
+      parseConditionalExpressionWithParens(
+        stream.current.value,
+        stream.current.index
+      )
+    );
+  }
+}
+
+/**
+ * A drop-in replacement for the standard assign tag that supports
+ * inline `if` expressions with a logical `not` operator and grouping
+ * terms with parentheses.
+ */
+export class ConditionalAssignTagWithParens extends AssignTag {
+  protected parseExpression(value: string, startIndex: number): Expression {
+    return parseConditionalExpressionWithParens(value, startIndex);
+  }
+}
+
+/**
+ * A drop-in replacement for the standard echo tag that supports
+ * inline `if` expressions with a logical `not` operator and grouping
+ * terms with parentheses.
+ */
+export class ConditionalEchoTagWithParens extends EchoTag {
+  protected parseExpression(value: string, startIndex: number): Expression {
+    return parseConditionalExpressionWithParens(value, startIndex);
+  }
+}

--- a/src/extra/tags/index.ts
+++ b/src/extra/tags/index.ts
@@ -1,3 +1,4 @@
-export * from "./with";
+export * from "./if_expressions";
 export * from "./ifnot";
 export * from "./macro";
+export * from "./with";

--- a/tests/eval_filtered_expression.test.ts
+++ b/tests/eval_filtered_expression.test.ts
@@ -304,13 +304,12 @@ const conditionalExpressionTestCases: Case[] = [
     expression: "'foo' | upcase if false else 'bar'",
     want: "bar",
   },
-  // FIXME:
-  // {
-  //   description: "missing condition",
-  //   globals: {},
-  //   expression: "'foo' if",
-  //   want: null,
-  // },
+  {
+    description: "missing condition",
+    globals: {},
+    expression: "'foo' if",
+    want: null,
+  },
   {
     description: "missing alternative",
     globals: {},
@@ -329,20 +328,20 @@ const notConditionalExpressionTestCases: Case[] = [
   {
     description: "string literal with true condition",
     globals: {},
-    expression: "'foo' if true",
-    want: "foo",
+    expression: "'foo' if not true",
+    want: null,
   },
   {
     description: "string literal with false condition",
     globals: {},
-    expression: "'foo' if false",
-    want: null,
+    expression: "'foo' if not false",
+    want: "foo",
   },
   {
     description: "string literal with false condition and alternative",
     globals: {},
-    expression: "'foo' if false else 'bar'",
-    want: "bar",
+    expression: "'foo' if not false else 'bar'",
+    want: "foo",
   },
   {
     description: "object and condition from context",
@@ -352,8 +351,8 @@ const notConditionalExpressionTestCases: Case[] = [
       },
       greeting: "hello",
     },
-    expression: "greeting if settings.foo else 'bar'",
-    want: "hello",
+    expression: "greeting if not settings.foo else 'bar'",
+    want: "bar",
   },
   {
     description: "object and condition from context with tail filter",
@@ -363,20 +362,20 @@ const notConditionalExpressionTestCases: Case[] = [
       },
       greeting: "hello",
     },
-    expression: "greeting if settings.foo else 'bar' || upcase",
-    want: "HELLO",
+    expression: "greeting if not settings.foo else 'bar' || upcase",
+    want: "BAR",
   },
   {
     description: "object filter with true condition",
     globals: {},
-    expression: "'foo' | upcase if true else 'bar'",
-    want: "FOO",
+    expression: "'foo' | upcase if not true else 'bar'",
+    want: "bar",
   },
   {
     description: "object filter with false condition",
     globals: {},
-    expression: "'foo' | upcase if false else 'bar'",
-    want: "bar",
+    expression: "'foo' | upcase if not false else 'bar'",
+    want: "FOO",
   },
 ];
 

--- a/tests/eval_filtered_expression.test.ts
+++ b/tests/eval_filtered_expression.test.ts
@@ -1,0 +1,444 @@
+import { RenderContext } from "../src/context";
+import { Environment } from "../src/environment";
+import { parse as parseFilteredExpression } from "../src/expressions/filtered/parse";
+import {
+  parse as parseConditionalExpression,
+  parseWithParens as parseConditionalExpressionWithParens,
+} from "../src/expressions/conditional/parse";
+import { Float, Integer } from "../src/number";
+import { Undefined } from "../src/undefined";
+
+type Case = {
+  description: string;
+  globals: { [index: string]: unknown };
+  expression: string;
+  want: unknown;
+};
+
+const filteredExpressionTestCases: Case[] = [
+  {
+    description: "string literal",
+    globals: {},
+    expression: "'foobar'",
+    want: "foobar",
+  },
+  {
+    description: "integer literal",
+    globals: {},
+    expression: "7",
+    want: new Integer(7),
+  },
+  {
+    description: "float literal",
+    globals: {},
+    expression: "7.5",
+    want: new Float(7.5),
+  },
+  {
+    description: "negative integer literal",
+    globals: {},
+    expression: "-7",
+    want: new Integer(-7),
+  },
+  {
+    description: "negative float literal",
+    globals: {},
+    expression: "-7.5",
+    want: new Float(-7.5),
+  },
+  {
+    description: "single global object identifier",
+    globals: {
+      collection: "foo",
+    },
+    expression: "collection",
+    want: "foo",
+  },
+  {
+    description: "string literal with no arg filter",
+    globals: {},
+    expression: "'foo' | upcase",
+    want: "FOO",
+  },
+  {
+    description: "object identifier with no arg filter",
+    globals: {
+      collection: {
+        title: "foo",
+      },
+    },
+    expression: "collection.title | upcase",
+    want: "FOO",
+  },
+  {
+    description: "string literal with two arg filter",
+    globals: {},
+    expression: '"Liquid" | slice: 2, 5',
+    want: "quid",
+  },
+  {
+    description: "string literal with two filters",
+    globals: {},
+    expression: '"Liquid" | slice: 2, 5 | upcase',
+    want: "QUID",
+  },
+  {
+    description: "resolve identifier chain",
+    globals: {
+      a: {
+        b: {
+          c: "hello",
+          array: [1, 2, 3],
+        },
+      },
+    },
+    expression: "a.b.c",
+    want: "hello",
+  },
+  {
+    description: "resolve identifier chain containing whitespace.",
+    globals: {
+      a: {
+        "b x": {
+          c: "hello",
+          array: [1, 2, 3],
+        },
+      },
+    },
+    expression: "a['b x'].c",
+    want: "hello",
+  },
+  {
+    description: "resolve identifier chain ending in an array",
+    globals: {
+      a: {
+        b: {
+          c: "hello",
+          array: [1, 2, 3],
+        },
+      },
+    },
+    expression: "a.b.array",
+    want: [1, 2, 3],
+  },
+  {
+    description:
+      "resolve identifier chain ending in an array index using subscript",
+    globals: {
+      a: {
+        b: {
+          c: "hello",
+          array: [1, 2, 3],
+        },
+      },
+    },
+    expression: "a.b.array[1]",
+    want: 2,
+  },
+  {
+    description: "array `first` special method",
+    globals: {
+      a: {
+        b: {
+          c: "hello",
+          array: [1, 2, 3],
+        },
+      },
+    },
+    expression: "a.b.array.first",
+    want: 1,
+  },
+  {
+    description: "array `last` special method",
+    globals: {
+      a: {
+        b: {
+          c: "hello",
+          array: [1, 2, 3],
+        },
+      },
+    },
+    expression: "a.b.array.last",
+    want: 3,
+  },
+  {
+    description: "array `size` special method",
+    globals: {
+      a: {
+        b: {
+          c: "hello",
+          array: [1, 2, 3],
+        },
+      },
+    },
+    expression: "a.b.array.size",
+    want: 3,
+  },
+  {
+    description: "size of an empty array",
+    globals: {
+      a: {
+        b: {
+          c: "hello",
+          array: [],
+        },
+      },
+    },
+    expression: "a.b.array.size",
+    want: 0,
+  },
+  {
+    description: "size of an object",
+    globals: {
+      a: {
+        b: {
+          c: "hello",
+          array: [],
+        },
+      },
+    },
+    expression: "a.b.size",
+    want: 2,
+  },
+  {
+    description: "nested and chained",
+    globals: {
+      linklists: {
+        main: "main menu",
+      },
+      section: {
+        settings: {
+          menu: "main",
+        },
+      },
+    },
+    expression: "linklists[section.settings.menu]",
+    want: "main menu",
+  },
+  {
+    description: "array index using negative subscript",
+    globals: {
+      a: [1, 2, 3],
+    },
+    expression: "a[-1]",
+    want: 3,
+  },
+  {
+    description: "resolve identifier chain not in context",
+    globals: {
+      a: {
+        b: {
+          c: "hello",
+          array: [1, 2, 3],
+        },
+      },
+    },
+    expression: "a.b.x",
+    want: null,
+  },
+  {
+    description: "try to read past an array",
+    globals: {
+      a: {
+        b: {
+          c: "hello",
+          array: [1, 2, 3],
+        },
+      },
+    },
+    expression: "a.b.array.foo",
+    want: null,
+  },
+];
+
+const conditionalExpressionTestCases: Case[] = [
+  {
+    description: "string literal with true condition",
+    globals: {},
+    expression: "'foo' if true",
+    want: "foo",
+  },
+  {
+    description: "string literal with false condition",
+    globals: {},
+    expression: "'foo' if false",
+    want: null,
+  },
+  {
+    description: "string literal with false condition and alternative",
+    globals: {},
+    expression: "'foo' if false else 'bar'",
+    want: "bar",
+  },
+  {
+    description: "object and condition from context",
+    globals: {
+      settings: {
+        foo: true,
+      },
+      greeting: "hello",
+    },
+    expression: "greeting if settings.foo else 'bar'",
+    want: "hello",
+  },
+  {
+    description: "object and condition from context with tail filter",
+    globals: {
+      settings: {
+        foo: true,
+      },
+      greeting: "hello",
+    },
+    expression: "greeting if settings.foo else 'bar' || upcase",
+    want: "HELLO",
+  },
+  {
+    description: "object filter with true condition",
+    globals: {},
+    expression: "'foo' | upcase if true else 'bar'",
+    want: "FOO",
+  },
+  {
+    description: "object filter with false condition",
+    globals: {},
+    expression: "'foo' | upcase if false else 'bar'",
+    want: "bar",
+  },
+  // FIXME:
+  // {
+  //   description: "missing condition",
+  //   globals: {},
+  //   expression: "'foo' if",
+  //   want: null,
+  // },
+  {
+    description: "missing alternative",
+    globals: {},
+    expression: "'foo' if false else",
+    want: null,
+  },
+  {
+    description: "missing condition followed by else",
+    globals: {},
+    expression: "'foo' if else 'bar'",
+    want: "bar",
+  },
+];
+
+const notConditionalExpressionTestCases: Case[] = [
+  {
+    description: "string literal with true condition",
+    globals: {},
+    expression: "'foo' if true",
+    want: "foo",
+  },
+  {
+    description: "string literal with false condition",
+    globals: {},
+    expression: "'foo' if false",
+    want: null,
+  },
+  {
+    description: "string literal with false condition and alternative",
+    globals: {},
+    expression: "'foo' if false else 'bar'",
+    want: "bar",
+  },
+  {
+    description: "object and condition from context",
+    globals: {
+      settings: {
+        foo: true,
+      },
+      greeting: "hello",
+    },
+    expression: "greeting if settings.foo else 'bar'",
+    want: "hello",
+  },
+  {
+    description: "object and condition from context with tail filter",
+    globals: {
+      settings: {
+        foo: true,
+      },
+      greeting: "hello",
+    },
+    expression: "greeting if settings.foo else 'bar' || upcase",
+    want: "HELLO",
+  },
+  {
+    description: "object filter with true condition",
+    globals: {},
+    expression: "'foo' | upcase if true else 'bar'",
+    want: "FOO",
+  },
+  {
+    description: "object filter with false condition",
+    globals: {},
+    expression: "'foo' | upcase if false else 'bar'",
+    want: "bar",
+  },
+];
+
+describe("eval standard filtered expression", () => {
+  const env = new Environment();
+  test.each<Case>(filteredExpressionTestCases)(
+    "$description",
+    async ({ globals, expression, want }: Case) => {
+      const context = new RenderContext(env, globals);
+      const expr = parseFilteredExpression(expression);
+      if (want === null) {
+        expect(expr.evaluateSync(context)).toBeInstanceOf(Undefined);
+        expect(expr.evaluate(context)).resolves.toBeInstanceOf(Undefined);
+      } else {
+        expect(expr.evaluateSync(context)).toStrictEqual(want);
+        expect(expr.evaluate(context)).resolves.toStrictEqual(want);
+      }
+    }
+  );
+});
+
+describe("eval conditional filtered expression", () => {
+  const testCases = [
+    ...filteredExpressionTestCases,
+    ...conditionalExpressionTestCases,
+  ];
+  const env = new Environment();
+  test.each<Case>(testCases)(
+    "$description",
+    async ({ globals, expression, want }: Case) => {
+      const context = new RenderContext(env, globals);
+      const expr = parseConditionalExpression(expression);
+      if (want === null) {
+        expect(expr.evaluateSync(context)).toBeInstanceOf(Undefined);
+        expect(expr.evaluate(context)).resolves.toBeInstanceOf(Undefined);
+      } else {
+        expect(expr.evaluateSync(context)).toStrictEqual(want);
+        expect(expr.evaluate(context)).resolves.toStrictEqual(want);
+      }
+    }
+  );
+});
+
+describe("eval extended conditional filtered expression", () => {
+  const testCases = [
+    ...filteredExpressionTestCases,
+    ...conditionalExpressionTestCases,
+    ...notConditionalExpressionTestCases,
+  ];
+  const env = new Environment();
+  test.each<Case>(testCases)(
+    "$description",
+    async ({ globals, expression, want }: Case) => {
+      const context = new RenderContext(env, globals);
+      const expr = parseConditionalExpressionWithParens(expression);
+      if (want === null) {
+        expect(expr.evaluateSync(context)).toBeInstanceOf(Undefined);
+        expect(expr.evaluate(context)).resolves.toBeInstanceOf(Undefined);
+      } else {
+        expect(expr.evaluateSync(context)).toStrictEqual(want);
+        expect(expr.evaluate(context)).resolves.toStrictEqual(want);
+      }
+    }
+  );
+});

--- a/tests/parse_filtered_expression.test.ts
+++ b/tests/parse_filtered_expression.test.ts
@@ -8,8 +8,13 @@ import {
   RangeLiteral,
   StringLiteral,
   TRUE,
+  ConditionalExpression,
+  NIL,
+  PrefixExpression,
 } from "../src/expression";
 import { parse } from "../src/expressions/filtered/parse";
+import { parse as parseConditionalExpression } from "../src/expressions/conditional/parse";
+import { parseWithParens as parseConditionalExpressionWithParens } from "../src/expressions/conditional/parse";
 import { Float, Integer } from "../src/number";
 
 describe("parse filtered expression", () => {
@@ -88,6 +93,45 @@ describe("parse filtered expression", () => {
           new Map<string, Expression>([["allow_false", TRUE]])
         ),
       ])
+    );
+  });
+});
+
+describe("parse conditional expression", () => {
+  test("true condition", () => {
+    const expr = parseConditionalExpression("'foo' if true");
+    expect(expr).toStrictEqual(
+      new ConditionalExpression(
+        new FilteredExpression(new StringLiteral("foo"), []),
+        [],
+        TRUE,
+        NIL
+      )
+    );
+  });
+  test("missing condition", () => {
+    const expr = parseConditionalExpression("'foo' if");
+    expect(expr).toStrictEqual(
+      new ConditionalExpression(
+        new FilteredExpression(new StringLiteral("foo"), []),
+        [],
+        FALSE,
+        NIL
+      )
+    );
+  });
+});
+
+describe("parse conditional expression with not", () => {
+  test("simple negation", () => {
+    const expr = parseConditionalExpressionWithParens("'foo' if not true");
+    expect(expr).toStrictEqual(
+      new ConditionalExpression(
+        new FilteredExpression(new StringLiteral("foo"), []),
+        [],
+        new PrefixExpression("not", TRUE),
+        NIL
+      )
     );
   });
 });

--- a/tests/tags/extra/if_expressions.test.ts
+++ b/tests/tags/extra/if_expressions.test.ts
@@ -1,0 +1,271 @@
+import { Environment } from "../../../src/environment";
+import {
+  ConditionalAssignTag,
+  ConditionalAssignTagWithParens,
+  ConditionalEchoTag,
+  ConditionalEchoTagWithParens,
+  ConditionalOutputStatement,
+  ConditionalOutputStatementWithParens,
+} from "../../../src/extra/tags/if_expressions";
+
+type Case = {
+  description: string;
+  text: string;
+  want: unknown;
+  globals: { [index: string]: unknown };
+};
+
+const conditionalOutputStatementTestCases: Case[] = [
+  {
+    description: "string literal with true condition",
+    text: "{{ 'hello' if true }}",
+    want: "hello",
+    globals: {},
+  },
+  {
+    description: "default to undefined",
+    text: "{{ 'hello' if false }}",
+    want: "",
+    globals: {},
+  },
+  {
+    description: "early filter",
+    text: "{{ 'hello' | upcase if true }}",
+    want: "HELLO",
+    globals: {},
+  },
+  {
+    description: "string literal with false condition and alternative",
+    text: "{{ 'hello' if false else 'goodbye' }}",
+    want: "goodbye",
+    globals: {},
+  },
+  {
+    description: "object and condition from context with tail filter",
+    text: "{{ greeting if settings.foo else 'bar' || upcase }}",
+    want: "HELLO",
+    globals: {
+      settings: {
+        foo: true,
+      },
+      greeting: "hello",
+    },
+  },
+];
+
+const conditionalAssignTagTestCases: Case[] = [
+  {
+    description: "string literal",
+    text: "{% assign foo = 'hello' %}{{ foo }}",
+    want: "hello",
+    globals: {},
+  },
+  {
+    description: "string literal with true condition",
+    text: "{% assign foo = 'hello' if true %}{{ foo }}",
+    want: "hello",
+    globals: {},
+  },
+  {
+    description: "default to undefined",
+    text: "{% assign foo = 'hello' if false %}{{ foo }}",
+    want: "",
+    globals: {},
+  },
+  {
+    description: "early filter",
+    text: "{% assign foo = 'hello' | upcase if true %}{{ foo }}",
+    want: "HELLO",
+    globals: {},
+  },
+  {
+    description: "string literal with false condition and alternative",
+    text: "{% assign foo = 'hello' if false else 'goodbye' %}{{ foo }}",
+    want: "goodbye",
+    globals: {},
+  },
+  {
+    description: "object and condition from context with tail filter",
+    text: "{% assign foo = greeting if settings.foo else 'bar' || upcase %}{{ foo }}",
+    want: "HELLO",
+    globals: {
+      settings: {
+        foo: true,
+      },
+      greeting: "hello",
+    },
+  },
+];
+
+const conditionalEchoTagTestCases: Case[] = [
+  {
+    description: "string literal",
+    text: "{% echo 'hello' %}",
+    want: "hello",
+    globals: {},
+  },
+  {
+    description: "string literal with true condition",
+    text: "{% echo 'hello' if true %}",
+    want: "hello",
+    globals: {},
+  },
+  {
+    description: "default to undefined",
+    text: "{% echo 'hello' if false %}",
+    want: "",
+    globals: {},
+  },
+  {
+    description: "early  filter",
+    text: "{% echo 'hello' | upcase if true %}",
+    want: "HELLO",
+    globals: {},
+  },
+  {
+    description: "string literal with false condition and alternative",
+    text: "{% echo 'hello' if false else 'goodbye' %}",
+    want: "goodbye",
+    globals: {},
+  },
+  {
+    description: "object and condition from context with tail filter",
+    text: "{% echo greeting if settings.foo else 'bar' || upcase %}",
+    want: "HELLO",
+    globals: {
+      settings: {
+        foo: true,
+      },
+      greeting: "hello",
+    },
+  },
+];
+
+const notConditionalOutputStatementTestCases: Case[] = [
+  {
+    description: "negate condition",
+    text: "{{ 'hello' if not false else 'goodbye' }}",
+    want: "hello",
+    globals: {},
+  },
+  {
+    description: "group condition terms",
+    text: "{{ 'hello' if (false and true) or true }}",
+    want: "hello",
+    globals: {},
+  },
+];
+
+const notConditionalAssignTagTestCases: Case[] = [
+  {
+    description: "negate condition",
+    text: "{% assign foo = 'hello' if not false else 'goodbye' %}{{ foo }}",
+    want: "hello",
+    globals: {},
+  },
+  {
+    description: "group condition terms",
+    text: "{% assign foo = 'hello' if (false and true) or true %}{{ foo }}",
+    want: "hello",
+    globals: {},
+  },
+];
+
+const notConditionalEchoTagTestCases: Case[] = [
+  {
+    description: "negate condition",
+    text: "{% echo 'hello' if not false else 'goodbye' %}",
+    want: "hello",
+    globals: {},
+  },
+  {
+    description: "group condition terms",
+    text: "{% echo 'hello' if (false and true) or true %}",
+    want: "hello",
+    globals: {},
+  },
+];
+
+describe("render conditional output statement", () => {
+  const env = new Environment();
+  env.addTag("statement", new ConditionalOutputStatement());
+
+  test.each<Case>(conditionalOutputStatementTestCases)(
+    "$description",
+    async ({ globals, text, want }: Case) => {
+      const template = env.fromString(text);
+      expect(template.renderSync(globals)).toStrictEqual(want);
+      expect(template.render(globals)).resolves.toStrictEqual(want);
+    }
+  );
+});
+
+describe("render conditional assign tag", () => {
+  const env = new Environment();
+  env.addTag("assign", new ConditionalAssignTag());
+
+  test.each<Case>(conditionalAssignTagTestCases)(
+    "$description",
+    async ({ globals, text, want }: Case) => {
+      const template = env.fromString(text);
+      expect(template.renderSync(globals)).toStrictEqual(want);
+      expect(template.render(globals)).resolves.toStrictEqual(want);
+    }
+  );
+});
+
+describe("render conditional echo tag", () => {
+  const env = new Environment();
+  env.addTag("echo", new ConditionalEchoTag());
+
+  test.each<Case>(conditionalEchoTagTestCases)(
+    "$description",
+    async ({ globals, text, want }: Case) => {
+      const template = env.fromString(text);
+      expect(template.renderSync(globals)).toStrictEqual(want);
+      expect(template.render(globals)).resolves.toStrictEqual(want);
+    }
+  );
+});
+
+describe("render extended conditional output statement", () => {
+  const env = new Environment();
+  env.addTag("statement", new ConditionalOutputStatementWithParens());
+
+  test.each<Case>([
+    ...conditionalOutputStatementTestCases,
+    ...notConditionalOutputStatementTestCases,
+  ])("$description", async ({ globals, text, want }: Case) => {
+    const template = env.fromString(text);
+    expect(template.renderSync(globals)).toStrictEqual(want);
+    expect(template.render(globals)).resolves.toStrictEqual(want);
+  });
+});
+
+describe("render extended conditional assign tag", () => {
+  const env = new Environment();
+  env.addTag("assign", new ConditionalAssignTagWithParens());
+
+  test.each<Case>([
+    ...conditionalAssignTagTestCases,
+    ...notConditionalAssignTagTestCases,
+  ])("$description", async ({ globals, text, want }: Case) => {
+    const template = env.fromString(text);
+    expect(template.renderSync(globals)).toStrictEqual(want);
+    expect(template.render(globals)).resolves.toStrictEqual(want);
+  });
+});
+
+describe("render extended conditional echo tag", () => {
+  const env = new Environment();
+  env.addTag("echo", new ConditionalEchoTagWithParens());
+
+  test.each<Case>([
+    ...conditionalEchoTagTestCases,
+    ...notConditionalEchoTagTestCases,
+  ])("$description", async ({ globals, text, want }: Case) => {
+    const template = env.fromString(text);
+    expect(template.renderSync(globals)).toStrictEqual(want);
+    expect(template.render(globals)).resolves.toStrictEqual(want);
+  });
+});

--- a/tests/tokenize_filtered_expression.test.ts
+++ b/tests/tokenize_filtered_expression.test.ts
@@ -1,223 +1,444 @@
 import { Token } from "../src/token";
 import { tokenize } from "../src/expressions/filtered/lex";
+import {
+  tokenize as tokenizeConditional,
+  tokenizeWithParens as tokenizeConditionalWithParens,
+} from "../src/expressions/conditional/lex";
 
 import {
+  TOKEN_AND,
   TOKEN_COLON,
   TOKEN_COMMA,
   TOKEN_DOT,
+  TOKEN_DPIPE,
+  TOKEN_ELSE,
+  TOKEN_FALSE,
   TOKEN_FLOAT,
   TOKEN_IDENT,
   TOKEN_IDENT_INDEX,
+  TOKEN_IF,
   TOKEN_INTEGER,
   TOKEN_LBRACKET,
   TOKEN_LPAREN,
+  TOKEN_LT,
+  TOKEN_NOT,
   TOKEN_PIPE,
   TOKEN_RANGE,
   TOKEN_RBRACKET,
   TOKEN_RPAREN,
   TOKEN_STRING,
+  TOKEN_TRUE,
 } from "../src/expressions/tokens";
 
-describe("tokenize filtered expressions", () => {
-  test("double quoted string literal", () => {
-    const tokens = Array.from(tokenize('"hello"'));
-    expect(tokens).toStrictEqual([
-      new Token(TOKEN_STRING, "hello", 0, '"hello"'),
-    ]);
-  });
-  test("single quoted string literal", () => {
-    const tokens = Array.from(tokenize("'hello'"));
-    expect(tokens).toStrictEqual([
-      new Token(TOKEN_STRING, "hello", 0, "'hello'"),
-    ]);
-  });
-  test("single quoted string representation of a float", () => {
-    const tokens = Array.from(tokenize("'42.2'"));
-    expect(tokens).toStrictEqual([
-      new Token(TOKEN_STRING, "42.2", 0, "'42.2'"),
-    ]);
-  });
-  test("integer literal", () => {
-    const tokens = Array.from(tokenize("42"));
-    expect(tokens).toStrictEqual([new Token(TOKEN_INTEGER, "42", 0, "42")]);
-  });
-  test("negative integer literal", () => {
-    const tokens = Array.from(tokenize("-42"));
-    expect(tokens).toStrictEqual([new Token(TOKEN_INTEGER, "-42", 0, "-42")]);
-  });
-  test("float literal", () => {
-    const tokens = Array.from(tokenize("1.34"));
-    expect(tokens).toStrictEqual([new Token(TOKEN_FLOAT, "1.34", 0, "1.34")]);
-  });
-  test("negative float literal", () => {
-    const tokens = Array.from(tokenize("-1.34"));
-    expect(tokens).toStrictEqual([new Token(TOKEN_FLOAT, "-1.34", 0, "-1.34")]);
-  });
-  test("float literal without a digit after the decimal point", () => {
-    const tokens = Array.from(tokenize("2."));
-    expect(tokens).toStrictEqual([new Token(TOKEN_FLOAT, "2.", 0, "2.")]);
-  });
-  test("negative float literal without a digit after the decimal point", () => {
-    const tokens = Array.from(tokenize("-2."));
-    expect(tokens).toStrictEqual([new Token(TOKEN_FLOAT, "-2.", 0, "-2.")]);
-  });
-  test("simple identifier", () => {
-    const tokens = Array.from(tokenize("products"));
-    expect(tokens).toStrictEqual([
-      new Token(TOKEN_IDENT, "products", 0, "products"),
-    ]);
-  });
-  test("simple identifier with a hyphen", () => {
-    const tokens = Array.from(tokenize("some-products"));
-    expect(tokens).toStrictEqual([
-      new Token(TOKEN_IDENT, "some-products", 0, "some-products"),
-    ]);
-  });
-  test("simple identifier with a trailing question mark", () => {
-    const tokens = Array.from(tokenize("products?"));
-    expect(tokens).toStrictEqual([
-      new Token(TOKEN_IDENT, "products?", 0, "products?"),
-    ]);
-  });
-  test("simple identifier with a leading underscore", () => {
-    const tokens = Array.from(tokenize("_products"));
-    expect(tokens).toStrictEqual([
-      new Token(TOKEN_IDENT, "_products", 0, "_products"),
-    ]);
-  });
-  test("simple identifier with a leading digit", () => {
-    expect(() => Array.from(tokenize("1products"))).toThrow(
-      "unexpected token '1'"
+// Table-driven test case object.
+type Case = {
+  description: string;
+  text: string;
+  want: PartialToken[];
+};
+
+// Minimal token information for each test case. The rest can be inferred from
+// the test case.
+type PartialToken = {
+  kind: string;
+  value: string;
+  index?: number;
+};
+
+// Test cases for tokenizing "standard" filtered expressions.
+const filteredExpressionTestCases: Case[] = [
+  {
+    description: "double quoted string literal",
+    text: '"hello"',
+    want: [{ kind: TOKEN_STRING, value: "hello" }],
+  },
+  {
+    description: "single quoted string literal",
+    text: "'hello'",
+    want: [{ kind: TOKEN_STRING, value: "hello" }],
+  },
+  {
+    description: "single quoted string representation of a float",
+    text: "'42.2'",
+    want: [{ kind: TOKEN_STRING, value: "42.2" }],
+  },
+  {
+    description: "integer literal",
+    text: "42",
+    want: [{ kind: TOKEN_INTEGER, value: "42" }],
+  },
+  {
+    description: "negative integer literal",
+    text: "-42",
+    want: [{ kind: TOKEN_INTEGER, value: "-42" }],
+  },
+  {
+    description: "float literal",
+    text: "1.34",
+    want: [{ kind: TOKEN_FLOAT, value: "1.34" }],
+  },
+  {
+    description: "negative float literal",
+    text: "-1.34",
+    want: [{ kind: TOKEN_FLOAT, value: "-1.34" }],
+  },
+  {
+    description: "float literal without a digit after the decimal point",
+    text: "2.",
+    want: [{ kind: TOKEN_FLOAT, value: "2." }],
+  },
+  {
+    description:
+      "negative float literal without a digit after the decimal point",
+    text: "-2.",
+    want: [{ kind: TOKEN_FLOAT, value: "-2." }],
+  },
+  {
+    description: "simple identifier",
+    text: "products",
+    want: [{ kind: TOKEN_IDENT, value: "products" }],
+  },
+  {
+    description: "simple identifier with a hyphen",
+    text: "some-products",
+    want: [{ kind: TOKEN_IDENT, value: "some-products" }],
+  },
+  {
+    description: "simple identifier with a trailing question mark",
+    text: "products?",
+    want: [{ kind: TOKEN_IDENT, value: "products?" }],
+  },
+  {
+    description: "simple identifier with a leading underscore",
+    text: "_products",
+    want: [{ kind: TOKEN_IDENT, value: "_products" }],
+  },
+  {
+    description: "dotted variable",
+    text: "collection.products",
+    want: [
+      { kind: TOKEN_IDENT, value: "collection" },
+      { kind: TOKEN_DOT, value: ".", index: 10 },
+      { kind: TOKEN_IDENT, value: "products", index: 11 },
+    ],
+  },
+  {
+    description: "bracketed index",
+    text: "products[1]",
+    want: [
+      { kind: TOKEN_IDENT, value: "products" },
+      { kind: TOKEN_IDENT_INDEX, value: "1", index: 8 },
+    ],
+  },
+  {
+    description: "bracketed single quoted property",
+    text: "collection['products']",
+    want: [
+      { kind: TOKEN_IDENT, value: "collection" },
+      { kind: TOKEN_IDENT, value: "products", index: 10 },
+    ],
+  },
+  {
+    description: "bracketed double quoted property",
+    text: 'collection["products"]',
+    want: [
+      { kind: TOKEN_IDENT, value: "collection" },
+      { kind: TOKEN_IDENT, value: "products", index: 10 },
+    ],
+  },
+  {
+    description: "nested dotted variable",
+    text: "collection[tags.current_collection]",
+    want: [
+      { kind: TOKEN_IDENT, value: "collection" },
+      { kind: TOKEN_LBRACKET, value: "[", index: 10 },
+      { kind: TOKEN_IDENT, value: "tags", index: 11 },
+      { kind: TOKEN_DOT, value: ".", index: 15 },
+      { kind: TOKEN_IDENT, value: "current_collection", index: 16 },
+      { kind: TOKEN_RBRACKET, value: "]", index: 34 },
+    ],
+  },
+  {
+    description: "filtered string literal",
+    text: '"hello" | upcase',
+    want: [
+      { kind: TOKEN_STRING, value: "hello" },
+      { kind: TOKEN_PIPE, value: "|", index: 8 },
+      { kind: TOKEN_IDENT, value: "upcase", index: 10 },
+    ],
+  },
+  {
+    description: "filtered variable",
+    text: "name | upcase",
+    want: [
+      { kind: TOKEN_IDENT, value: "name" },
+      { kind: TOKEN_PIPE, value: "|", index: 5 },
+      { kind: TOKEN_IDENT, value: "upcase", index: 7 },
+    ],
+  },
+  {
+    description: "filter with integer argument",
+    text: "4 | at_least: 5",
+    want: [
+      { kind: TOKEN_INTEGER, value: "4" },
+      { kind: TOKEN_PIPE, value: "|", index: 2 },
+      { kind: TOKEN_IDENT, value: "at_least", index: 4 },
+      { kind: TOKEN_COLON, value: ":", index: 12 },
+      { kind: TOKEN_INTEGER, value: "5", index: 14 },
+    ],
+  },
+  {
+    description: "filter with two arguments",
+    text: "'Liquid' | slice: 2, 5",
+    want: [
+      { kind: TOKEN_STRING, value: "Liquid" },
+      { kind: TOKEN_PIPE, value: "|", index: 9 },
+      { kind: TOKEN_IDENT, value: "slice", index: 11 },
+      { kind: TOKEN_COLON, value: ":", index: 16 },
+      { kind: TOKEN_INTEGER, value: "2", index: 18 },
+      { kind: TOKEN_COMMA, value: ",", index: 19 },
+      { kind: TOKEN_INTEGER, value: "5", index: 21 },
+    ],
+  },
+  {
+    description: "inconsistent whitespace",
+    text: "\n'Liquid'\n |slice: 2,5",
+    want: [
+      { kind: TOKEN_STRING, value: "Liquid", index: 1 },
+      { kind: TOKEN_PIPE, value: "|", index: 11 },
+      { kind: TOKEN_IDENT, value: "slice", index: 12 },
+      { kind: TOKEN_COLON, value: ":", index: 17 },
+      { kind: TOKEN_INTEGER, value: "2", index: 19 },
+      { kind: TOKEN_COMMA, value: ",", index: 20 },
+      { kind: TOKEN_INTEGER, value: "5", index: 21 },
+    ],
+  },
+  {
+    description: "range literal",
+    text: "(1..5)",
+    want: [
+      { kind: TOKEN_LPAREN, value: "(", index: 0 },
+      { kind: TOKEN_INTEGER, value: "1", index: 1 },
+      { kind: TOKEN_RANGE, value: "..", index: 2 },
+      { kind: TOKEN_INTEGER, value: "5", index: 4 },
+      { kind: TOKEN_RPAREN, value: ")", index: 5 },
+    ],
+  },
+  {
+    description: "range literal with float start",
+    text: "(2.4..5)",
+    want: [
+      { kind: TOKEN_LPAREN, value: "(", index: 0 },
+      { kind: TOKEN_FLOAT, value: "2.4", index: 1 },
+      { kind: TOKEN_RANGE, value: "..", index: 4 },
+      { kind: TOKEN_INTEGER, value: "5", index: 6 },
+      { kind: TOKEN_RPAREN, value: ")", index: 7 },
+    ],
+  },
+  {
+    description: "range literal with identifiers for start and stop",
+    text: "(a..b)",
+    want: [
+      { kind: TOKEN_LPAREN, value: "(", index: 0 },
+      { kind: TOKEN_IDENT, value: "a", index: 1 },
+      { kind: TOKEN_RANGE, value: "..", index: 2 },
+      { kind: TOKEN_IDENT, value: "b", index: 4 },
+      { kind: TOKEN_RPAREN, value: ")", index: 5 },
+    ],
+  },
+];
+
+// Test cases for tokenizing conditional filtered expressions. Those that
+// support inline if/else expressions.
+const conditionalExpressionTestCases: Case[] = [
+  {
+    description: "simple condition",
+    text: "'foo' if true",
+    want: [
+      { kind: TOKEN_STRING, value: "foo" },
+      { kind: TOKEN_IF, value: "if", index: 6 },
+      { kind: TOKEN_TRUE, value: "true", index: 9 },
+    ],
+  },
+  {
+    description: "comparison operator",
+    text: "'foo' if x < y",
+    want: [
+      { kind: TOKEN_STRING, value: "foo" },
+      { kind: TOKEN_IF, value: "if", index: 6 },
+      { kind: TOKEN_IDENT, value: "x", index: 9 },
+      { kind: TOKEN_LT, value: "<", index: 11 },
+      { kind: TOKEN_IDENT, value: "y", index: 13 },
+    ],
+  },
+  {
+    description: "condition with alternative",
+    text: "'foo' if true else 'bar'",
+    want: [
+      { kind: TOKEN_STRING, value: "foo" },
+      { kind: TOKEN_IF, value: "if", index: 6 },
+      { kind: TOKEN_TRUE, value: "true", index: 9 },
+      { kind: TOKEN_ELSE, value: "else", index: 14 },
+      { kind: TOKEN_STRING, value: "bar", index: 19 },
+    ],
+  },
+  {
+    description: "condition with preceding filter",
+    text: "'foo' | upcase if true else 'bar'",
+    want: [
+      { kind: TOKEN_STRING, value: "foo" },
+      { kind: TOKEN_PIPE, value: "|", index: 6 },
+      { kind: TOKEN_IDENT, value: "upcase", index: 8 },
+      { kind: TOKEN_IF, value: "if", index: 15 },
+      { kind: TOKEN_TRUE, value: "true", index: 18 },
+      { kind: TOKEN_ELSE, value: "else", index: 23 },
+      { kind: TOKEN_STRING, value: "bar", index: 28 },
+    ],
+  },
+  {
+    description: "condition with alternative filter",
+    text: "'foo' if true else 'bar' | upcase",
+    want: [
+      { kind: TOKEN_STRING, value: "foo" },
+      { kind: TOKEN_IF, value: "if", index: 6 },
+      { kind: TOKEN_TRUE, value: "true", index: 9 },
+      { kind: TOKEN_ELSE, value: "else", index: 14 },
+      { kind: TOKEN_STRING, value: "bar", index: 19 },
+      { kind: TOKEN_PIPE, value: "|", index: 25 },
+      { kind: TOKEN_IDENT, value: "upcase", index: 27 },
+    ],
+  },
+  {
+    description: "condition with tail filter",
+    text: "'foo' if true else 'bar' || upcase",
+    want: [
+      { kind: TOKEN_STRING, value: "foo" },
+      { kind: TOKEN_IF, value: "if", index: 6 },
+      { kind: TOKEN_TRUE, value: "true", index: 9 },
+      { kind: TOKEN_ELSE, value: "else", index: 14 },
+      { kind: TOKEN_STRING, value: "bar", index: 19 },
+      { kind: TOKEN_DPIPE, value: "||", index: 25 },
+      { kind: TOKEN_IDENT, value: "upcase", index: 28 },
+    ],
+  },
+  {
+    description: "multi-line condition with tail filter",
+    text: "'foo'\nif true\nelse 'bar' || upcase",
+    want: [
+      { kind: TOKEN_STRING, value: "foo" },
+      { kind: TOKEN_IF, value: "if", index: 6 },
+      { kind: TOKEN_TRUE, value: "true", index: 9 },
+      { kind: TOKEN_ELSE, value: "else", index: 14 },
+      { kind: TOKEN_STRING, value: "bar", index: 19 },
+      { kind: TOKEN_DPIPE, value: "||", index: 25 },
+      { kind: TOKEN_IDENT, value: "upcase", index: 28 },
+    ],
+  },
+];
+
+// Test cases for tokenizing conditional filtered expression that allow
+// the logical `not` operator and grouping terms with parentheses.
+const notConditionalExpressionTestCases: Case[] = [
+  {
+    description: "negated condition",
+    text: "'foo' if not true",
+    want: [
+      { kind: TOKEN_STRING, value: "foo" },
+      { kind: TOKEN_IF, value: "if", index: 6 },
+      { kind: TOKEN_NOT, value: "not", index: 9 },
+      { kind: TOKEN_TRUE, value: "true", index: 13 },
+    ],
+  },
+  {
+    description: "negated condition with alternative",
+    text: "'foo' if not true else 'bar'",
+    want: [
+      { kind: TOKEN_STRING, value: "foo" },
+      { kind: TOKEN_IF, value: "if", index: 6 },
+      { kind: TOKEN_NOT, value: "not", index: 9 },
+      { kind: TOKEN_TRUE, value: "true", index: 13 },
+      { kind: TOKEN_ELSE, value: "else", index: 18 },
+      { kind: TOKEN_STRING, value: "bar", index: 23 },
+    ],
+  },
+  {
+    description: "grouped condition with alternative",
+    text: "'foo' if not (false and false) else 'bar'",
+    want: [
+      { kind: TOKEN_STRING, value: "foo" },
+      { kind: TOKEN_IF, value: "if", index: 6 },
+      { kind: TOKEN_NOT, value: "not", index: 9 },
+      { kind: TOKEN_LPAREN, value: "(", index: 13 },
+      { kind: TOKEN_FALSE, value: "false", index: 14 },
+      { kind: TOKEN_AND, value: "and", index: 20 },
+      { kind: TOKEN_FALSE, value: "false", index: 24 },
+      { kind: TOKEN_RPAREN, value: ")", index: 29 },
+      { kind: TOKEN_ELSE, value: "else", index: 31 },
+      { kind: TOKEN_STRING, value: "bar", index: 36 },
+    ],
+  },
+  {
+    description: "negated condition with preceding filter",
+    text: "'foo' | upcase if not true else 'bar'",
+    want: [
+      { kind: TOKEN_STRING, value: "foo", index: 0 },
+      { kind: TOKEN_PIPE, value: "|", index: 6 },
+      { kind: TOKEN_IDENT, value: "upcase", index: 8 },
+      { kind: TOKEN_IF, value: "if", index: 15 },
+      { kind: TOKEN_NOT, value: "not", index: 18 },
+      { kind: TOKEN_TRUE, value: "true", index: 22 },
+      { kind: TOKEN_ELSE, value: "else", index: 27 },
+      { kind: TOKEN_STRING, value: "bar", index: 32 },
+    ],
+  },
+];
+
+describe("standard filtered expression lexer", () => {
+  test.each<Case>(filteredExpressionTestCases)(
+    "$description",
+    ({ text, want }: Case) => {
+      const _want = want.map(
+        (t) => new Token(t.kind, t.value, t.index || 0, text)
+      );
+      const tokens = Array.from(tokenize(text));
+      expect(tokens).toStrictEqual(_want);
+    }
+  );
+});
+
+describe("conditional filtered expression lexer", () => {
+  // Combine standard test cases with conditional test cases.
+  const testCases = [
+    ...filteredExpressionTestCases,
+    ...conditionalExpressionTestCases,
+  ];
+  test.each<Case>(testCases)("$description", ({ text, want }: Case) => {
+    const _want = want.map(
+      (t) => new Token(t.kind, t.value, t.index || 0, text)
     );
+    const tokens = Array.from(tokenizeConditional(text));
+    expect(tokens).toStrictEqual(_want);
   });
-  test("simple chained identifier", () => {
-    const tokens = Array.from(tokenize("collection.products"));
-    expect(tokens).toStrictEqual([
-      new Token(TOKEN_IDENT, "collection", 0, "collection.products"),
-      new Token(TOKEN_DOT, ".", 10, "collection.products"),
-      new Token(TOKEN_IDENT, "products", 11, "collection.products"),
-    ]);
-  });
-  test("simple indexed identifier", () => {
-    const tokens = Array.from(tokenize("products[1]"));
-    expect(tokens).toStrictEqual([
-      new Token(TOKEN_IDENT, "products", 0, "products[1]"),
-      new Token(TOKEN_IDENT_INDEX, "1", 8, "products[1]"),
-    ]);
-  });
-  test("bracketed single quoted identifier", () => {
-    const tokens = Array.from(tokenize("collection['products']"));
-    expect(tokens).toStrictEqual([
-      new Token(TOKEN_IDENT, "collection", 0, "collection['products']"),
-      new Token(TOKEN_IDENT, "products", 10, "collection['products']"),
-    ]);
-  });
-  test("bracketed double quoted identifier", () => {
-    const tokens = Array.from(tokenize('collection["products"]'));
-    expect(tokens).toStrictEqual([
-      new Token(TOKEN_IDENT, "collection", 0, 'collection["products"]'),
-      new Token(TOKEN_IDENT, "products", 10, 'collection["products"]'),
-    ]);
-  });
-  test("bracketed nested identifier", () => {
-    const tokens = Array.from(tokenize("collection[tags.current_collection]"));
-    expect(tokens).toStrictEqual([
-      new Token(
-        TOKEN_IDENT,
-        "collection",
-        0,
-        "collection[tags.current_collection]"
-      ),
-      new Token(TOKEN_LBRACKET, "[", 10, "collection[tags.current_collection]"),
-      new Token(TOKEN_IDENT, "tags", 11, "collection[tags.current_collection]"),
-      new Token(TOKEN_DOT, ".", 15, "collection[tags.current_collection]"),
-      new Token(
-        TOKEN_IDENT,
-        "current_collection",
-        16,
-        "collection[tags.current_collection]"
-      ),
-      new Token(TOKEN_RBRACKET, "]", 34, "collection[tags.current_collection]"),
-    ]);
-  });
-  test("filtered string literal", () => {
-    const tokens = Array.from(tokenize('"hello" | upcase'));
-    expect(tokens).toStrictEqual([
-      new Token(TOKEN_STRING, "hello", 0, '"hello" | upcase'),
-      new Token(TOKEN_PIPE, "|", 8, '"hello" | upcase'),
-      new Token(TOKEN_IDENT, "upcase", 10, '"hello" | upcase'),
-    ]);
-  });
-  test("filtered identifier", () => {
-    const tokens = Array.from(tokenize("name | upcase"));
-    expect(tokens).toStrictEqual([
-      new Token(TOKEN_IDENT, "name", 0, "name | upcase"),
-      new Token(TOKEN_PIPE, "|", 5, "name | upcase"),
-      new Token(TOKEN_IDENT, "upcase", 7, "name | upcase"),
-    ]);
-  });
-  test("filtered integer literal with integer argument", () => {
-    const tokens = Array.from(tokenize("4 | at_least: 5"));
-    expect(tokens).toStrictEqual([
-      new Token(TOKEN_INTEGER, "4", 0, "4 | at_least: 5"),
-      new Token(TOKEN_PIPE, "|", 2, "4 | at_least: 5"),
-      new Token(TOKEN_IDENT, "at_least", 4, "4 | at_least: 5"),
-      new Token(TOKEN_COLON, ":", 12, "4 | at_least: 5"),
-      new Token(TOKEN_INTEGER, "5", 14, "4 | at_least: 5"),
-    ]);
-  });
-  test("filtered string with two argument", () => {
-    const tokens = Array.from(tokenize("'Liquid' | slice: 2, 5"));
-    expect(tokens).toStrictEqual([
-      new Token(TOKEN_STRING, "Liquid", 0, "'Liquid' | slice: 2, 5"),
-      new Token(TOKEN_PIPE, "|", 9, "'Liquid' | slice: 2, 5"),
-      new Token(TOKEN_IDENT, "slice", 11, "'Liquid' | slice: 2, 5"),
-      new Token(TOKEN_COLON, ":", 16, "'Liquid' | slice: 2, 5"),
-      new Token(TOKEN_INTEGER, "2", 18, "'Liquid' | slice: 2, 5"),
-      new Token(TOKEN_COMMA, ",", 19, "'Liquid' | slice: 2, 5"),
-      new Token(TOKEN_INTEGER, "5", 21, "'Liquid' | slice: 2, 5"),
-    ]);
-  });
-  test("handle whitespace", () => {
-    const tokens = Array.from(tokenize("\n'Liquid'\n |slice: 2,5"));
-    expect(tokens).toStrictEqual([
-      new Token(TOKEN_STRING, "Liquid", 1, "\n'Liquid'\n |slice: 2,5"),
-      new Token(TOKEN_PIPE, "|", 11, "\n'Liquid'\n |slice: 2,5"),
-      new Token(TOKEN_IDENT, "slice", 12, "\n'Liquid'\n |slice: 2,5"),
-      new Token(TOKEN_COLON, ":", 17, "\n'Liquid'\n |slice: 2,5"),
-      new Token(TOKEN_INTEGER, "2", 19, "\n'Liquid'\n |slice: 2,5"),
-      new Token(TOKEN_COMMA, ",", 20, "\n'Liquid'\n |slice: 2,5"),
-      new Token(TOKEN_INTEGER, "5", 21, "\n'Liquid'\n |slice: 2,5"),
-    ]);
-  });
-  test("range literal", () => {
-    const tokens = Array.from(tokenize("(1..5)"));
-    expect(tokens).toStrictEqual([
-      new Token(TOKEN_LPAREN, "(", 0, "(1..5)"),
-      new Token(TOKEN_INTEGER, "1", 1, "(1..5)"),
-      new Token(TOKEN_RANGE, "..", 2, "(1..5)"),
-      new Token(TOKEN_INTEGER, "5", 4, "(1..5)"),
-      new Token(TOKEN_RPAREN, ")", 5, "(1..5)"),
-    ]);
-  });
-  test("range literal with float start", () => {
-    const tokens = Array.from(tokenize("(2.4..5)"));
-    expect(tokens).toStrictEqual([
-      new Token(TOKEN_LPAREN, "(", 0, "(2.4..5)"),
-      new Token(TOKEN_FLOAT, "2.4", 1, "(2.4..5)"),
-      new Token(TOKEN_RANGE, "..", 4, "(2.4..5)"),
-      new Token(TOKEN_INTEGER, "5", 6, "(2.4..5)"),
-      new Token(TOKEN_RPAREN, ")", 7, "(2.4..5)"),
-    ]);
-  });
-  test("range literal with identifiers for start and stop", () => {
-    const tokens = Array.from(tokenize("(a..b)"));
-    expect(tokens).toStrictEqual([
-      new Token(TOKEN_LPAREN, "(", 0, "(a..b)"),
-      new Token(TOKEN_IDENT, "a", 1, "(a..b)"),
-      new Token(TOKEN_RANGE, "..", 2, "(a..b)"),
-      new Token(TOKEN_IDENT, "b", 4, "(a..b)"),
-      new Token(TOKEN_RPAREN, ")", 5, "(a..b)"),
-    ]);
+});
+
+describe("extended conditional filtered expression lexer", () => {
+  // Combine standard test cases with conditional test cases, including
+  // `not` and parens.
+  const testCases = [
+    ...filteredExpressionTestCases,
+    ...conditionalExpressionTestCases,
+    ...notConditionalExpressionTestCases,
+  ];
+  test.each<Case>(testCases)("$description", ({ text, want }: Case) => {
+    const _want = want.map(
+      (t) => new Token(t.kind, t.value, t.index || 0, text)
+    );
+    const tokens = Array.from(tokenizeConditionalWithParens(text));
+    const tokenKinds = new Set(want.map((t) => t.kind));
+    if (tokenKinds.has(TOKEN_RANGE)) {
+      expect(tokens).not.toStrictEqual(_want);
+    } else {
+      expect(tokens).toStrictEqual(_want);
+    }
   });
 });


### PR DESCRIPTION
This pull request adds drop-in replacements for the standard output statement (`{{ something }}`), `assign` tag and `echo` tag that support inline conditional (`if`/`else`) expressions. Closes #8.

```liquid
{{ 'hello user' if user.logged_in else 'please log in' }}
```

Is equivalent to ..

```liquid
{%  if user.logged_in -%}
  hello user
{%- else -%}
  please log in
{%- endif %}
```

Support for a logical `not` operator and grouping terms with parentheses is optional.