### PR TITLE
feat: analyse tags and filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added the standard `sum` filter, which returns the sum of any numeric values in its input array.
 - Added optional `{% extends %}` and `{% block %}` tags that add template inheritance features to Liquid templates.
+- Added `filter` and `tag` properties to the result of `Template.analyze()`, containing the locations of filters and tags found during static analysis. 
 
 ## Version 1.7.0
 

--- a/docs/docs/guides/static-analysis.md
+++ b/docs/docs/guides/static-analysis.md
@@ -73,7 +73,7 @@ const template = Template.fromString(`\
 
 const analysis = template.analyzeSync();
 
-for (const [name, locations] of Object.entries(a.globalVariables)) {
+for (const [name, locations] of Object.entries(analysis.globalVariables)) {
   for (const { templateName, lineNumber } of locations) {
     console.log(
       `'${name}' is out of scope in '${templateName}' on line ${lineNumber}`
@@ -99,7 +99,7 @@ const template = Template.fromString(`\
 
 const analysis = template.analyzeSync();
 
-for (const [name, locations] of Object.entries(a.localVariables)) {
+for (const [name, locations] of Object.entries(analysis.localVariables)) {
   for (const { templateName, lineNumber } of locations) {
     console.log(
       `'${name}' assigned in '${templateName}' on line ${lineNumber}`
@@ -111,6 +111,71 @@ for (const [name, locations] of Object.entries(a.localVariables)) {
 ```plain title="output"
 'people' assigned in '<string>' on line 1
 'people' assigned in '<string>' on line 2
+```
+
+## Filters
+
+**_New in version 1.8.0_**
+
+The `filters` property of [`TemplateAnalysis`](../api/modules.md#templateanalysis) is an object mapping filter names to their locations.
+
+
+```javascript
+import { Template } from "liquidscript";
+
+const template = Template.fromString(`\
+{% assign people = "Sally, John, Brian, Sue" | split: ", " %}
+{% for person in people %}
+  - {{ person | upcase | prepend: 'Hello, ' }}
+{% endfor %}`);
+
+const analysis = template.analyzeSync();
+
+for (const [filterName, locations] of Object.entries(analysis.filters)) {
+  for (const { templateName, lineNumber } of locations) {
+    console.log(
+      `'${filterName}' found in '${templateName}' on line ${lineNumber}`
+    );
+  }
+}
+```
+
+```plain title="output"
+'split' found in '<string>' on line 1
+'upcase' found in '<string>' on line 3
+'prepend' found in '<string>' on line 3
+```
+
+## Tags
+
+**_New in version 1.8.0_**
+
+The `tags` property of [`TemplateAnalysis`](../api/modules.md#templateanalysis) is an object mapping tag names to their locations. Note that, for block tags, we only report the locations of the opening tag, and `{% raw %}` tags will never be included.
+
+
+```javascript
+import { Template } from "liquidscript";
+
+const template = Template.fromString(`\
+{% assign people = "Sally, John, Brian, Sue" | split: ", " %}
+{% for person in people %}
+  - {{ person | upcase | prepend: 'Hello, ' }}
+{% endfor %}`);
+
+const analysis = template.analyzeSync();
+
+for (const [tagName, locations] of Object.entries(analysis.tags)) {
+  for (const { templateName, lineNumber } of locations) {
+    console.log(
+      `'${tagName}' found in '${templateName}' on line ${lineNumber}`
+    );
+  }
+}
+```
+
+```plain title="output"
+'assign' found in '<string>' on line 1
+'for' found in '<string>' on line 2
 ```
 
 ## Analyzing Partial Templates

--- a/src/static_analysis.ts
+++ b/src/static_analysis.ts
@@ -234,9 +234,9 @@ export class TemplateVariableCounter {
     }
 
     for (const child of root.children()) {
-      this._analyzeExpression(child);
-      await this._expressionHook(child);
-      this._updateTemplateScope(child);
+      this.analyzeExpression(child);
+      await this.expressionHook(child);
+      this.updateTemplateScope(child);
 
       if (child.blockScope) {
         this.scope[chainPush](
@@ -247,13 +247,13 @@ export class TemplateVariableCounter {
       if (this.followPartials) {
         switch (child.loadMode) {
           case "include":
-            await this._analyzeInclude(child);
+            await this.analyzeInclude(child);
             break;
           case "render":
-            await this._analyzeRender(child);
+            await this.analyzeRender(child);
             break;
           case "extends":
-            await this._analyzeTemplateInheritanceChain(child, this.template);
+            await this.analyzeTemplateInheritanceChain(child, this.template);
             throw new StopRender("stop static analysis");
           case undefined:
             break;
@@ -288,9 +288,9 @@ export class TemplateVariableCounter {
     }
 
     for (const child of root.children()) {
-      this._analyzeExpression(child);
-      this._expressionHookSync(child);
-      this._updateTemplateScope(child);
+      this.analyzeExpression(child);
+      this.expressionHookSync(child);
+      this.updateTemplateScope(child);
 
       if (child.blockScope) {
         this.scope[chainPush](
@@ -301,13 +301,13 @@ export class TemplateVariableCounter {
       if (this.followPartials) {
         switch (child.loadMode) {
           case "include":
-            this._analyzeIncludeSync(child);
+            this.analyzeIncludeSync(child);
             break;
           case "render":
-            this._analyzeRenderSync(child);
+            this.analyzeRenderSync(child);
             break;
           case "extends":
-            this._analyzeTemplateInheritanceChainSync(child, this.template);
+            this.analyzeTemplateInheritanceChainSync(child, this.template);
             throw new StopRender("stop static analysis");
           case undefined:
             break;
@@ -329,7 +329,7 @@ export class TemplateVariableCounter {
     }
   }
 
-  private _analyzeExpression(child: ChildNode): void {
+  private analyzeExpression(child: ChildNode): void {
     if (!child.expression) return;
     if (!child.expression.children) {
       // This expression does not define a children method.
@@ -340,7 +340,7 @@ export class TemplateVariableCounter {
       });
     }
 
-    const refs = this._updateExpressionRefs(child.expression);
+    const refs = this.updateExpressionRefs(child.expression);
 
     for (const ref of refs.variables) {
       this.variables.get(ref).push({
@@ -370,7 +370,7 @@ export class TemplateVariableCounter {
     }
   }
 
-  private _updateTemplateScope(child: ChildNode): void {
+  private updateTemplateScope(child: ChildNode): void {
     if (child.templateScope) {
       for (const name of child.templateScope) {
         this.templateLocals.get(name).push({
@@ -381,7 +381,7 @@ export class TemplateVariableCounter {
     }
   }
 
-  private _updateExpressionRefs(expression: Expression): ExpressionRefs {
+  private updateExpressionRefs(expression: Expression): ExpressionRefs {
     const refs: ExpressionRefs = { variables: [], filters: [] };
 
     if (expression instanceof Identifier) {
@@ -392,7 +392,7 @@ export class TemplateVariableCounter {
 
     if (expression.children) {
       for (const expr of expression.children()) {
-        for (const child of this._updateExpressionRefs(expr).variables) {
+        for (const child of this.updateExpressionRefs(expr).variables) {
           refs.variables.push(child);
         }
       }
@@ -401,8 +401,8 @@ export class TemplateVariableCounter {
     return refs;
   }
 
-  private async _analyzeInclude(child: ChildNode): Promise<void> {
-    const { templateName, loadContext } = this._includeContext(child);
+  private async analyzeInclude(child: ChildNode): Promise<void> {
+    const { templateName, loadContext } = this.includeContext(child);
     if (templateName === undefined || loadContext === undefined) {
       return;
     }
@@ -410,7 +410,7 @@ export class TemplateVariableCounter {
     let template: Template;
 
     try {
-      template = await this._getTemplate(
+      template = await this.getTemplate(
         templateName,
         loadContext,
         this.templateName,
@@ -428,11 +428,11 @@ export class TemplateVariableCounter {
       partials: this.partials,
     }).analyze();
 
-    this._updateReferenceCounters(refs);
+    this.updateReferenceCounters(refs);
   }
 
-  private _analyzeIncludeSync(child: ChildNode): void {
-    const { templateName, loadContext } = this._includeContext(child);
+  private analyzeIncludeSync(child: ChildNode): void {
+    const { templateName, loadContext } = this.includeContext(child);
     if (templateName === undefined || loadContext === undefined) {
       return;
     }
@@ -440,7 +440,7 @@ export class TemplateVariableCounter {
     let template: Template;
 
     try {
-      template = this._getTemplateSync(
+      template = this.getTemplateSync(
         templateName,
         loadContext,
         this.templateName,
@@ -458,10 +458,10 @@ export class TemplateVariableCounter {
       partials: this.partials,
     }).analyzeSync();
 
-    this._updateReferenceCounters(refs);
+    this.updateReferenceCounters(refs);
   }
 
-  private _includeContext(child: ChildNode): Partial<PartialTemplateContext> {
+  private includeContext(child: ChildNode): Partial<PartialTemplateContext> {
     if (child.expression === undefined) {
       return {};
     }
@@ -494,8 +494,8 @@ export class TemplateVariableCounter {
     return context;
   }
 
-  private async _analyzeRender(child: ChildNode): Promise<void> {
-    const { templateName, loadContext } = this._renderContext(child);
+  private async analyzeRender(child: ChildNode): Promise<void> {
+    const { templateName, loadContext } = this.renderContext(child);
     if (templateName === undefined || loadContext === undefined) {
       return;
     }
@@ -503,7 +503,7 @@ export class TemplateVariableCounter {
     let template: Template;
 
     try {
-      template = await this._getTemplate(
+      template = await this.getTemplate(
         templateName,
         loadContext,
         this.templateName,
@@ -530,11 +530,11 @@ export class TemplateVariableCounter {
       partials: this.partials,
     }).analyze();
 
-    this._updateReferenceCounters(refs);
+    this.updateReferenceCounters(refs);
   }
 
-  private _analyzeRenderSync(child: ChildNode): void {
-    const { templateName, loadContext } = this._renderContext(child);
+  private analyzeRenderSync(child: ChildNode): void {
+    const { templateName, loadContext } = this.renderContext(child);
     if (templateName === undefined || loadContext === undefined) {
       return;
     }
@@ -542,7 +542,7 @@ export class TemplateVariableCounter {
     let template: Template;
 
     try {
-      template = this._getTemplateSync(
+      template = this.getTemplateSync(
         templateName,
         loadContext,
         this.templateName,
@@ -569,14 +569,14 @@ export class TemplateVariableCounter {
       partials: this.partials,
     }).analyzeSync();
 
-    this._updateReferenceCounters(refs);
+    this.updateReferenceCounters(refs);
   }
 
-  private async _analyzeTemplateInheritanceChain(
+  private async analyzeTemplateInheritanceChain(
     node: ChildNode,
     template: Template,
   ): Promise<void> {
-    const { templateName, loadContext } = this._renderContext(node);
+    const { templateName, loadContext } = this.renderContext(node);
     if (templateName === undefined || loadContext === undefined) {
       return;
     }
@@ -591,7 +591,7 @@ export class TemplateVariableCounter {
     const seen = new Set<string>();
 
     // Add blocks from the leaf template tot he stack context.
-    let stacked = this._stackBlocks(stackContext, template, false);
+    let stacked = this.stackBlocks(stackContext, template, false);
     if (stacked.extendsNode === undefined) {
       throw new InternalSyntaxError(`expected an 'extends' node`);
     }
@@ -600,7 +600,7 @@ export class TemplateVariableCounter {
     let parent: Template | undefined;
 
     try {
-      parent = await this._getTemplate(
+      parent = await this.getTemplate(
         templateName,
         loadContext,
         this.templateName,
@@ -611,12 +611,12 @@ export class TemplateVariableCounter {
       throw error;
     }
 
-    stacked = this._stackBlocks(stackContext, parent);
-    let parentTemplateName: string | undefined = this._extend(stacked, seen);
+    stacked = this.stackBlocks(stackContext, parent);
+    let parentTemplateName: string | undefined = this.extend(stacked, seen);
 
     while (parentTemplateName) {
       try {
-        parent = await this._getTemplate(
+        parent = await this.getTemplate(
           parentTemplateName,
           loadContext,
           this.templateName,
@@ -626,8 +626,8 @@ export class TemplateVariableCounter {
         if (error instanceof TemplateNotFoundError) return;
         throw error;
       }
-      stacked = this._stackBlocks(stackContext, parent);
-      parentTemplateName = this._extend(stacked, seen);
+      stacked = this.stackBlocks(stackContext, parent);
+      parentTemplateName = this.extend(stacked, seen);
     }
 
     const refs = await new InheritanceChainCounter(
@@ -643,14 +643,14 @@ export class TemplateVariableCounter {
       },
     ).analyze();
 
-    this._updateReferenceCounters(refs);
+    this.updateReferenceCounters(refs);
   }
 
-  private _analyzeTemplateInheritanceChainSync(
+  private analyzeTemplateInheritanceChainSync(
     node: ChildNode,
     template: Template,
   ): void {
-    const { templateName, loadContext } = this._renderContext(node);
+    const { templateName, loadContext } = this.renderContext(node);
     if (templateName === undefined || loadContext === undefined) {
       return;
     }
@@ -665,7 +665,7 @@ export class TemplateVariableCounter {
     const seen = new Set<string>();
 
     // Add blocks from the leaf template tot he stack context.
-    let stacked = this._stackBlocks(stackContext, template, false);
+    let stacked = this.stackBlocks(stackContext, template, false);
     if (stacked.extendsNode === undefined) {
       throw new InternalSyntaxError(`expected an 'extends' node`);
     }
@@ -674,7 +674,7 @@ export class TemplateVariableCounter {
     let parent: Template;
 
     try {
-      parent = this._getTemplateSync(
+      parent = this.getTemplateSync(
         templateName,
         loadContext,
         this.templateName,
@@ -685,12 +685,12 @@ export class TemplateVariableCounter {
       throw error;
     }
 
-    stacked = this._stackBlocks(stackContext, parent);
-    let parentTemplateName: string | undefined = this._extend(stacked, seen);
+    stacked = this.stackBlocks(stackContext, parent);
+    let parentTemplateName: string | undefined = this.extend(stacked, seen);
 
     while (parentTemplateName) {
       try {
-        parent = this._getTemplateSync(
+        parent = this.getTemplateSync(
           parentTemplateName,
           loadContext,
           this.templateName,
@@ -700,8 +700,8 @@ export class TemplateVariableCounter {
         if (error instanceof TemplateNotFoundError) return;
         throw error;
       }
-      stacked = this._stackBlocks(stackContext, parent);
-      parentTemplateName = this._extend(stacked, seen);
+      stacked = this.stackBlocks(stackContext, parent);
+      parentTemplateName = this.extend(stacked, seen);
     }
 
     const refs = new InheritanceChainCounter(parent, stackContext, undefined, {
@@ -712,10 +712,10 @@ export class TemplateVariableCounter {
       partials: this.partials,
     }).analyzeSync();
 
-    this._updateReferenceCounters(refs);
+    this.updateReferenceCounters(refs);
   }
 
-  private _extend(
+  private extend(
     _stacked: StackedBlocks,
     seen: Set<string>,
   ): string | undefined {
@@ -733,7 +733,7 @@ export class TemplateVariableCounter {
     return undefined;
   }
 
-  private _stackBlocks(
+  private stackBlocks(
     stackContext: RenderContext,
     template: Template,
     countTags: boolean = true,
@@ -756,7 +756,7 @@ export class TemplateVariableCounter {
     return stacked;
   }
 
-  private async _getTemplate(
+  private async getTemplate(
     name: string,
     loaderContext: { [index: string]: unknown },
     parentName: string,
@@ -775,7 +775,7 @@ export class TemplateVariableCounter {
     }
   }
 
-  private _getTemplateSync(
+  private getTemplateSync(
     name: string,
     loaderContext: { [index: string]: unknown },
     parentName: string,
@@ -794,7 +794,7 @@ export class TemplateVariableCounter {
     }
   }
 
-  private _renderContext(child: ChildNode): Partial<PartialTemplateContext> {
+  private renderContext(child: ChildNode): Partial<PartialTemplateContext> {
     if (child.expression === undefined) {
       return {};
     }
@@ -834,7 +834,7 @@ export class TemplateVariableCounter {
   }
 
   // eslint-disable-next-line sonarjs/cognitive-complexity
-  protected _updateReferenceCounters(refs: TemplateVariableCounter): void {
+  protected updateReferenceCounters(refs: TemplateVariableCounter): void {
     for (const [_name, _refs] of refs.variables.entries()) {
       for (const location of _refs) {
         this.variables.get(_name).push(location);
@@ -902,10 +902,10 @@ export class TemplateVariableCounter {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected async _expressionHook(child: ChildNode): Promise<void> {}
+  protected async expressionHook(child: ChildNode): Promise<void> {}
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected _expressionHookSync(child: ChildNode): void {}
+  protected expressionHookSync(child: ChildNode): void {}
 }
 
 class InheritanceChainCounter extends TemplateVariableCounter {
@@ -932,27 +932,27 @@ class InheritanceChainCounter extends TemplateVariableCounter {
 
   protected async _analyze(root: Node): Promise<void> {
     if (root instanceof InheritanceBlockNode) {
-      return await this._analyzeBlock(root);
+      return await this.analyzeBlock(root);
     }
     return await super._analyze(root);
   }
 
   protected _analyzeSync(root: Node): void {
     if (root instanceof InheritanceBlockNode) {
-      return this._analyzeBlockSync(root);
+      return this.analyzeBlockSync(root);
     }
     return super._analyzeSync(root);
   }
 
-  protected async _expressionHook(child: ChildNode): Promise<void> {
+  protected async expressionHook(child: ChildNode): Promise<void> {
     if (
       !child.expression ||
       !this.parentBlockStackItem ||
-      !this._containsSuper(child.expression)
+      !this.containsSuper(child.expression)
     )
       return;
 
-    const template = this._makeTemplate(this.parentBlockStackItem);
+    const template = this.makeTemplate(this.parentBlockStackItem);
     const scope = Object.fromEntries(
       Array.from(this.templateLocals.keys()).map((s) => [
         s.split(InheritanceChainCounter.RE_SPLIT_IDENT, 1)[0],
@@ -972,18 +972,18 @@ class InheritanceChainCounter extends TemplateVariableCounter {
       },
     ).analyze();
 
-    this._updateReferenceCounters(refs);
+    this.updateReferenceCounters(refs);
   }
 
-  protected _expressionHookSync(child: ChildNode): void {
+  protected expressionHookSync(child: ChildNode): void {
     if (
       !child.expression ||
       !this.parentBlockStackItem ||
-      !this._containsSuper(child.expression)
+      !this.containsSuper(child.expression)
     )
       return;
 
-    const template = this._makeTemplate(this.parentBlockStackItem);
+    const template = this.makeTemplate(this.parentBlockStackItem);
     const scope = Object.fromEntries(
       Array.from(this.templateLocals.keys()).map((s) => [
         s.split(InheritanceChainCounter.RE_SPLIT_IDENT, 1)[0],
@@ -1003,10 +1003,10 @@ class InheritanceChainCounter extends TemplateVariableCounter {
       },
     ).analyzeSync();
 
-    this._updateReferenceCounters(refs);
+    this.updateReferenceCounters(refs);
   }
 
-  private _containsSuper(expression: Expression): boolean {
+  private containsSuper(expression: Expression): boolean {
     if (
       expression instanceof Identifier &&
       expression.toString() === "block.super"
@@ -1022,14 +1022,14 @@ class InheritanceChainCounter extends TemplateVariableCounter {
 
     if (expression.children) {
       for (const expr of expression.children()) {
-        if (this._containsSuper(expr)) return true;
+        if (this.containsSuper(expr)) return true;
       }
     }
 
     return false;
   }
 
-  private async _analyzeBlock(block: InheritanceBlockNode): Promise<void> {
+  private async analyzeBlock(block: InheritanceBlockNode): Promise<void> {
     const blockStacks = this.stackContext.getRegister(EXTENDS_REGISTER) as Map<
       string,
       BlockStackItem[]
@@ -1038,7 +1038,7 @@ class InheritanceChainCounter extends TemplateVariableCounter {
     const _blockStackItems = blockStacks.get(block.name);
     if (!_blockStackItems) return;
     const blockStackItem = _blockStackItems[0];
-    const template = this._makeTemplate(blockStackItem);
+    const template = this.makeTemplate(blockStackItem);
     const scope = Object.fromEntries(
       Array.from(this.templateLocals.keys()).map((s) => [
         s.split(InheritanceChainCounter.RE_SPLIT_IDENT, 1)[0],
@@ -1058,10 +1058,10 @@ class InheritanceChainCounter extends TemplateVariableCounter {
       },
     ).analyze();
 
-    this._updateReferenceCounters(refs);
+    this.updateReferenceCounters(refs);
   }
 
-  private _analyzeBlockSync(block: InheritanceBlockNode): void {
+  private analyzeBlockSync(block: InheritanceBlockNode): void {
     const blockStacks = this.stackContext.getRegister(EXTENDS_REGISTER) as Map<
       string,
       BlockStackItem[]
@@ -1070,7 +1070,7 @@ class InheritanceChainCounter extends TemplateVariableCounter {
     const _blockStackItems = blockStacks.get(block.name);
     if (!_blockStackItems) return;
     const blockStackItem = _blockStackItems[0];
-    const template = this._makeTemplate(blockStackItem);
+    const template = this.makeTemplate(blockStackItem);
     const scope = Object.fromEntries(
       Array.from(this.templateLocals.keys()).map((s) => [
         s.split(InheritanceChainCounter.RE_SPLIT_IDENT, 1)[0],
@@ -1090,10 +1090,10 @@ class InheritanceChainCounter extends TemplateVariableCounter {
       },
     ).analyzeSync();
 
-    this._updateReferenceCounters(refs);
+    this.updateReferenceCounters(refs);
   }
 
-  private _makeTemplate(item: BlockStackItem): Template {
+  private makeTemplate(item: BlockStackItem): Template {
     const parseTree = new Root();
     parseTree.nodes.push(...item.block.block.nodes);
     return new Template(

--- a/src/template.ts
+++ b/src/template.ts
@@ -288,6 +288,8 @@ export class Template {
       globalVariables: Object.fromEntries(refs.templateGlobals.entries()),
       failedVisits: Object.fromEntries(refs.failedVisits.entries()),
       unloadablePartials: Object.fromEntries(refs.unloadablePartials.entries()),
+      filters: Object.fromEntries(refs.filters.entries()),
+      tags: Object.fromEntries(refs.tags.entries()),
     };
   }
 
@@ -311,6 +313,8 @@ export class Template {
       globalVariables: Object.fromEntries(refs.templateGlobals.entries()),
       failedVisits: Object.fromEntries(refs.failedVisits.entries()),
       unloadablePartials: Object.fromEntries(refs.unloadablePartials.entries()),
+      filters: Object.fromEntries(refs.filters.entries()),
+      tags: Object.fromEntries(refs.tags.entries()),
     };
   }
 }

--- a/tests/analyze_template.test.ts
+++ b/tests/analyze_template.test.ts
@@ -70,9 +70,13 @@ describe("static template analysis", () => {
     failedVisits?: VariableRefs,
     unloadablePartials?: VariableRefs,
     raiseForFailures: boolean = true,
+    filters?: VariableRefs,
+    tags?: VariableRefs,
   ) {
     failedVisits = failedVisits ?? {};
     unloadablePartials = unloadablePartials ?? {};
+    filters = filters ?? {};
+    tags = tags ?? {};
 
     const expectRefs = (refs: TemplateAnalysis) => {
       expect(refs.failedVisits).toStrictEqual(failedVisits);
@@ -80,6 +84,8 @@ describe("static template analysis", () => {
       expect(refs.localVariables).toStrictEqual(locals);
       expect(refs.globalVariables).toStrictEqual(globals);
       expect(refs.variables).toStrictEqual(variables);
+      expect(refs.filters).toStrictEqual(filters);
+      expect(refs.tags).toStrictEqual(tags);
     };
 
     expectRefs(await template.analyze({ raiseForFailures }));
@@ -100,8 +106,20 @@ describe("static template analysis", () => {
       y: [{ templateName: "<string>", lineNumber: 1 }],
       z: [{ templateName: "<string>", lineNumber: 1 }],
     };
+    const expectedFilters: VariableRefs = {
+      default: [{ templateName: "<string>", lineNumber: 1 }],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      expectedFilters,
+    );
   });
 
   test("analyze identifier with bracketed string literal", async () => {
@@ -162,8 +180,24 @@ describe("static template analysis", () => {
       y: [{ templateName: "<string>", lineNumber: 1 }],
       z: [{ templateName: "<string>", lineNumber: 1 }],
     };
+    const expectedFilters: VariableRefs = {
+      append: [{ templateName: "<string>", lineNumber: 1 }],
+    };
+    const expectedTags: VariableRefs = {
+      assign: [{ templateName: "<string>", lineNumber: 1 }],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      expectedFilters,
+      expectedTags,
+    );
   });
 
   test("analyze capture tag", async () => {
@@ -180,8 +214,22 @@ describe("static template analysis", () => {
     const expectedVariables: VariableRefs = {
       y: [{ templateName: "<string>", lineNumber: 1 }],
     };
+    const expectedTags: VariableRefs = {
+      capture: [{ templateName: "<string>", lineNumber: 1 }],
+      if: [{ templateName: "<string>", lineNumber: 1 }],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      {},
+      expectedTags,
+    );
   });
 
   test("analyze case tag", async () => {
@@ -217,8 +265,21 @@ describe("static template analysis", () => {
       z: [{ templateName: "<string>", lineNumber: 4 }],
       b: [{ templateName: "<string>", lineNumber: 5 }],
     };
+    const expectedTags: VariableRefs = {
+      case: [{ templateName: "<string>", lineNumber: 1 }],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      {},
+      expectedTags,
+    );
   });
 
   test("analyze cycle tag", async () => {
@@ -235,8 +296,21 @@ describe("static template analysis", () => {
       a: [{ templateName: "<string>", lineNumber: 1 }],
       b: [{ templateName: "<string>", lineNumber: 1 }],
     };
+    const expectedTags: VariableRefs = {
+      cycle: [{ templateName: "<string>", lineNumber: 1 }],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      {},
+      expectedTags,
+    );
   });
 
   test("analyze decrement tag", async () => {
@@ -247,8 +321,21 @@ describe("static template analysis", () => {
       x: [{ templateName: "<string>", lineNumber: 1 }],
     };
     const expectedVariables: VariableRefs = {};
+    const expectedTags: VariableRefs = {
+      decrement: [{ templateName: "<string>", lineNumber: 1 }],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      {},
+      expectedTags,
+    );
   });
 
   test("analyze echo tag", async () => {
@@ -267,8 +354,24 @@ describe("static template analysis", () => {
       y: [{ templateName: "<string>", lineNumber: 1 }],
       z: [{ templateName: "<string>", lineNumber: 1 }],
     };
+    const expectedFilters: VariableRefs = {
+      default: [{ templateName: "<string>", lineNumber: 1 }],
+    };
+    const expectedTags: VariableRefs = {
+      echo: [{ templateName: "<string>", lineNumber: 1 }],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      expectedFilters,
+      expectedTags,
+    );
   });
 
   test("analyze for tag", async () => {
@@ -294,8 +397,24 @@ describe("static template analysis", () => {
       y: [{ templateName: "<string>", lineNumber: 1 }],
       z: [{ templateName: "<string>", lineNumber: 5 }],
     };
+    const expectedFilters: VariableRefs = {};
+    const expectedTags: VariableRefs = {
+      break: [{ templateName: "<string>", lineNumber: 3 }],
+      continue: [{ templateName: "<string>", lineNumber: 6 }],
+      for: [{ templateName: "<string>", lineNumber: 1 }],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      expectedFilters,
+      expectedTags,
+    );
   });
 
   test("analyze if tag", async () => {
@@ -322,8 +441,22 @@ describe("static template analysis", () => {
       y: [{ templateName: "<string>", lineNumber: 3 }],
       b: [{ templateName: "<string>", lineNumber: 4 }],
     };
+    const expectedFilters: VariableRefs = {};
+    const expectedTags: VariableRefs = {
+      if: [{ templateName: "<string>", lineNumber: 1 }],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      expectedFilters,
+      expectedTags,
+    );
   });
 
   test("analyze if (not) tag", async () => {
@@ -353,8 +486,22 @@ describe("static template analysis", () => {
       y: [{ templateName: "<string>", lineNumber: 3 }],
       b: [{ templateName: "<string>", lineNumber: 4 }],
     };
+    const expectedFilters: VariableRefs = {};
+    const expectedTags: VariableRefs = {
+      if: [{ templateName: "<string>", lineNumber: 1 }],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      expectedFilters,
+      expectedTags,
+    );
   });
 
   test("analyze ifchanged tag", async () => {
@@ -367,8 +514,22 @@ describe("static template analysis", () => {
     const expectedVariables: VariableRefs = {
       x: [{ templateName: "<string>", lineNumber: 1 }],
     };
+    const expectedFilters: VariableRefs = {};
+    const expectedTags: VariableRefs = {
+      ifchanged: [{ templateName: "<string>", lineNumber: 1 }],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      expectedFilters,
+      expectedTags,
+    );
   });
 
   test("analyze increment tag", async () => {
@@ -379,8 +540,22 @@ describe("static template analysis", () => {
       x: [{ templateName: "<string>", lineNumber: 1 }],
     };
     const expectedVariables: VariableRefs = {};
+    const expectedFilters: VariableRefs = {};
+    const expectedTags: VariableRefs = {
+      increment: [{ templateName: "<string>", lineNumber: 1 }],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      expectedFilters,
+      expectedTags,
+    );
   });
 
   test("analyze liquid tag", async () => {
@@ -409,8 +584,34 @@ describe("static template analysis", () => {
       foo: [{ templateName: "<string>", lineNumber: 3 }],
       i: [{ templateName: "<string>", lineNumber: 9 }],
     };
+    const expectedFilters: VariableRefs = {
+      upcase: [
+        { templateName: "<string>", lineNumber: 3 },
+        { templateName: "<string>", lineNumber: 5 },
+      ],
+    };
+    const expectedTags: VariableRefs = {
+      echo: [
+        { templateName: "<string>", lineNumber: 3 },
+        { templateName: "<string>", lineNumber: 5 },
+        { templateName: "<string>", lineNumber: 9 },
+      ],
+      for: [{ templateName: "<string>", lineNumber: 8 }],
+      if: [{ templateName: "<string>", lineNumber: 2 }],
+      liquid: [{ templateName: "<string>", lineNumber: 1 }],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      expectedFilters,
+      expectedTags,
+    );
   });
 
   test("analyze tablerow tag", async () => {
@@ -428,8 +629,24 @@ describe("static template analysis", () => {
       x: [{ templateName: "<string>", lineNumber: 1 }],
       a: [{ templateName: "<string>", lineNumber: 1 }],
     };
+    const expectedFilters: VariableRefs = {
+      append: [{ templateName: "<string>", lineNumber: 1 }],
+    };
+    const expectedTags: VariableRefs = {
+      tablerow: [{ templateName: "<string>", lineNumber: 1 }],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      expectedFilters,
+      expectedTags,
+    );
   });
 
   test("analyze unless tag", async () => {
@@ -456,8 +673,22 @@ describe("static template analysis", () => {
       y: [{ templateName: "<string>", lineNumber: 3 }],
       b: [{ templateName: "<string>", lineNumber: 4 }],
     };
+    const expectedFilters: VariableRefs = {};
+    const expectedTags: VariableRefs = {
+      unless: [{ templateName: "<string>", lineNumber: 1 }],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      expectedFilters,
+      expectedTags,
+    );
   });
 
   test("analyze include tag", async () => {
@@ -472,8 +703,22 @@ describe("static template analysis", () => {
     const expectedVariables: VariableRefs = {
       y: [{ templateName: "some_name", lineNumber: 1 }],
     };
+    const expectedFilters: VariableRefs = {};
+    const expectedTags: VariableRefs = {
+      include: [{ templateName: "<string>", lineNumber: 1 }],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      expectedFilters,
+      expectedTags,
+    );
   });
 
   test("analyze include tag with assign", async () => {
@@ -491,8 +736,23 @@ describe("static template analysis", () => {
       y: [{ templateName: "some_name", lineNumber: 1 }],
       z: [{ templateName: "<string>", lineNumber: 1 }],
     };
+    const expectedFilters: VariableRefs = {};
+    const expectedTags: VariableRefs = {
+      assign: [{ templateName: "some_name", lineNumber: 1 }],
+      include: [{ templateName: "<string>", lineNumber: 1 }],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      expectedFilters,
+      expectedTags,
+    );
   });
 
   test("analyze include tag once", async () => {
@@ -509,8 +769,25 @@ describe("static template analysis", () => {
     const expectedVariables: VariableRefs = {
       y: [{ templateName: "some_name", lineNumber: 1 }],
     };
+    const expectedFilters: VariableRefs = {};
+    const expectedTags: VariableRefs = {
+      include: [
+        { templateName: "<string>", lineNumber: 1 },
+        { templateName: "<string>", lineNumber: 1 },
+      ],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      expectedFilters,
+      expectedTags,
+    );
   });
 
   test("analyze recursive include tag", async () => {
@@ -527,8 +804,25 @@ describe("static template analysis", () => {
     const expectedVariables: VariableRefs = {
       y: [{ templateName: "some_name", lineNumber: 1 }],
     };
+    const expectedFilters: VariableRefs = {};
+    const expectedTags: VariableRefs = {
+      include: [
+        { templateName: "<string>", lineNumber: 1 },
+        { templateName: "some_name", lineNumber: 1 },
+      ],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      expectedFilters,
+      expectedTags,
+    );
   });
 
   test("analyze include tag with bound variable", async () => {
@@ -550,8 +844,24 @@ describe("static template analysis", () => {
       x: [{ templateName: "some_name", lineNumber: 1 }],
       some_name: [{ templateName: "some_name", lineNumber: 1 }],
     };
+    const expectedFilters: VariableRefs = {
+      append: [{ templateName: "some_name", lineNumber: 1 }],
+    };
+    const expectedTags: VariableRefs = {
+      include: [{ templateName: "<string>", lineNumber: 1 }],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      expectedFilters,
+      expectedTags,
+    );
   });
 
   test("analyze include tag with alias", async () => {
@@ -571,8 +881,24 @@ describe("static template analysis", () => {
       foo: [{ templateName: "<string>", lineNumber: 1 }],
       x: [{ templateName: "some_name", lineNumber: 1 }],
     };
+    const expectedFilters: VariableRefs = {
+      append: [{ templateName: "some_name", lineNumber: 1 }],
+    };
+    const expectedTags: VariableRefs = {
+      include: [{ templateName: "<string>", lineNumber: 1 }],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      expectedFilters,
+      expectedTags,
+    );
   });
 
   test("analyze include tag with arguments", async () => {
@@ -602,8 +928,24 @@ describe("static template analysis", () => {
         { templateName: "<string>", lineNumber: 1 },
       ],
     };
+    const expectedFilters: VariableRefs = {
+      append: [{ templateName: "some_name", lineNumber: 1 }],
+    };
+    const expectedTags: VariableRefs = {
+      include: [{ templateName: "<string>", lineNumber: 1 }],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      expectedFilters,
+      expectedTags,
+    );
   });
 
   test("analyze include with variable name", async () => {
@@ -622,6 +964,10 @@ describe("static template analysis", () => {
     const expectedUnloadablePartials = {
       somevar: [{ templateName: "<string>", lineNumber: 1 }],
     };
+    const expectedFilters: VariableRefs = {};
+    const expectedTags: VariableRefs = {
+      include: [{ templateName: "<string>", lineNumber: 1 }],
+    };
 
     await _test(
       template,
@@ -631,6 +977,8 @@ describe("static template analysis", () => {
       undefined,
       expectedUnloadablePartials,
       false,
+      expectedFilters,
+      expectedTags,
     );
 
     expect(async () =>
@@ -660,6 +1008,10 @@ describe("static template analysis", () => {
     const expectedUnloadablePartials: VariableRefs = {
       nosuchtemplate: [{ templateName: "<string>", lineNumber: 1 }],
     };
+    const expectedFilters: VariableRefs = {};
+    const expectedTags: VariableRefs = {
+      include: [{ templateName: "<string>", lineNumber: 1 }],
+    };
 
     await _test(
       template,
@@ -669,6 +1021,8 @@ describe("static template analysis", () => {
       undefined,
       expectedUnloadablePartials,
       false,
+      expectedFilters,
+      expectedTags,
     );
 
     expect(async () =>
@@ -702,8 +1056,26 @@ describe("static template analysis", () => {
       x: [{ templateName: "some_name", lineNumber: 1 }],
       z: [{ templateName: "some_name", lineNumber: 1 }],
     };
+    const expectedFilters: VariableRefs = {};
+    const expectedTags: VariableRefs = {
+      assign: [
+        { templateName: "<string>", lineNumber: 1 },
+        { templateName: "some_name", lineNumber: 1 },
+      ],
+      render: [{ templateName: "<string>", lineNumber: 1 }],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      expectedFilters,
+      expectedTags,
+    );
   });
 
   test("analyze render tag once", async () => {
@@ -720,8 +1092,25 @@ describe("static template analysis", () => {
     const expectedVariables: VariableRefs = {
       x: [{ templateName: "some_name", lineNumber: 1 }],
     };
+    const expectedFilters: VariableRefs = {};
+    const expectedTags: VariableRefs = {
+      render: [
+        { templateName: "<string>", lineNumber: 1 },
+        { templateName: "<string>", lineNumber: 1 },
+      ],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      expectedFilters,
+      expectedTags,
+    );
   });
 
   test("analyze recursive render tag", async () => {
@@ -738,8 +1127,25 @@ describe("static template analysis", () => {
     const expectedVariables: VariableRefs = {
       y: [{ templateName: "some_name", lineNumber: 1 }],
     };
+    const expectedFilters: VariableRefs = {};
+    const expectedTags: VariableRefs = {
+      render: [
+        { templateName: "<string>", lineNumber: 1 },
+        { templateName: "some_name", lineNumber: 1 },
+      ],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      expectedFilters,
+      expectedTags,
+    );
   });
 
   test("analyze render tag with bound variable", async () => {
@@ -761,8 +1167,24 @@ describe("static template analysis", () => {
       x: [{ templateName: "some_name", lineNumber: 1 }],
       some_name: [{ templateName: "some_name", lineNumber: 1 }],
     };
+    const expectedFilters: VariableRefs = {
+      append: [{ templateName: "some_name", lineNumber: 1 }],
+    };
+    const expectedTags: VariableRefs = {
+      render: [{ templateName: "<string>", lineNumber: 1 }],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      expectedFilters,
+      expectedTags,
+    );
   });
 
   test("analyze render tag with alias", async () => {
@@ -782,8 +1204,24 @@ describe("static template analysis", () => {
       foo: [{ templateName: "<string>", lineNumber: 1 }],
       x: [{ templateName: "some_name", lineNumber: 1 }],
     };
+    const expectedFilters: VariableRefs = {
+      append: [{ templateName: "some_name", lineNumber: 1 }],
+    };
+    const expectedTags: VariableRefs = {
+      render: [{ templateName: "<string>", lineNumber: 1 }],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      expectedFilters,
+      expectedTags,
+    );
   });
 
   test("analyze render tag with arguments", async () => {
@@ -813,8 +1251,24 @@ describe("static template analysis", () => {
         { templateName: "<string>", lineNumber: 1 },
       ],
     };
+    const expectedFilters: VariableRefs = {
+      append: [{ templateName: "some_name", lineNumber: 1 }],
+    };
+    const expectedTags: VariableRefs = {
+      render: [{ templateName: "<string>", lineNumber: 1 }],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      expectedFilters,
+      expectedTags,
+    );
   });
 
   test("analyze render tag scope", async () => {
@@ -837,8 +1291,26 @@ describe("static template analysis", () => {
       z: [{ templateName: "some_name", lineNumber: 1 }],
       y: [{ templateName: "<string>", lineNumber: 1 }],
     };
+    const expectedFilters: VariableRefs = {};
+    const expectedTags: VariableRefs = {
+      assign: [
+        { templateName: "<string>", lineNumber: 1 },
+        { templateName: "some_name", lineNumber: 1 },
+      ],
+      render: [{ templateName: "<string>", lineNumber: 1 }],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      expectedFilters,
+      expectedTags,
+    );
   });
 
   test("analyze render tag template not found", async () => {
@@ -855,6 +1327,10 @@ describe("static template analysis", () => {
     const expectedUnloadablePartials: VariableRefs = {
       nosuchtemplate: [{ templateName: "<string>", lineNumber: 1 }],
     };
+    const expectedFilters: VariableRefs = {};
+    const expectedTags: VariableRefs = {
+      render: [{ templateName: "<string>", lineNumber: 1 }],
+    };
 
     await _test(
       template,
@@ -864,6 +1340,8 @@ describe("static template analysis", () => {
       undefined,
       expectedUnloadablePartials,
       false,
+      expectedFilters,
+      expectedTags,
     );
 
     expect(async () =>
@@ -890,8 +1368,24 @@ describe("static template analysis", () => {
         { templateName: "<string>", lineNumber: 2 },
       ],
     };
+    const expectedTags = {
+      mock: [
+        { templateName: "<string>", lineNumber: 1 },
+        { templateName: "<string>", lineNumber: 2 },
+      ],
+    };
 
-    await _test(template, {}, {}, {}, expectedFailedVisits, {}, false);
+    await _test(
+      template,
+      {},
+      {},
+      {},
+      expectedFailedVisits,
+      {},
+      false,
+      {},
+      expectedTags,
+    );
 
     expect(async () =>
       _test(template, {}, {}, {}, expectedFailedVisits, {}, true),
@@ -909,8 +1403,24 @@ describe("static template analysis", () => {
         { templateName: "<string>", lineNumber: 2 },
       ],
     };
+    const expectedTags = {
+      mock: [
+        { templateName: "<string>", lineNumber: 1 },
+        { templateName: "<string>", lineNumber: 2 },
+      ],
+    };
 
-    await _test(template, {}, {}, {}, expectedFailedVisits, {}, false);
+    await _test(
+      template,
+      {},
+      {},
+      {},
+      expectedFailedVisits,
+      {},
+      false,
+      {},
+      expectedTags,
+    );
 
     expect(async () =>
       _test(template, {}, {}, {}, expectedFailedVisits, {}, true),
@@ -942,8 +1452,26 @@ describe("static template analysis", () => {
       you: [{ templateName: "<string>", lineNumber: 1 }],
       x: [{ templateName: "<string>", lineNumber: 1 }],
     };
+    const expectedTags: VariableRefs = {
+      assign: [{ templateName: "<string>", lineNumber: 1 }],
+      macro: [{ templateName: "<string>", lineNumber: 1 }],
+      call: [
+        { templateName: "<string>", lineNumber: 1 },
+        { templateName: "<string>", lineNumber: 1 },
+      ],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      {},
+      expectedTags,
+    );
   });
 
   test("analyze inheritance chain", async () => {
@@ -973,8 +1501,35 @@ describe("static template analysis", () => {
     const expectedVariables: VariableRefs = {
       x: [{ templateName: "other", lineNumber: 1 }],
     };
+    const expectedFilters: VariableRefs = {
+      downcase: [{ templateName: "other", lineNumber: 1 }],
+    };
+    const expectedTags: VariableRefs = {
+      assign: [{ templateName: "base", lineNumber: 1 }],
+      extends: [
+        { templateName: "some", lineNumber: 1 },
+        { templateName: "other", lineNumber: 1 },
+      ],
+      block: [
+        { templateName: "some", lineNumber: 1 },
+        { templateName: "other", lineNumber: 1 },
+        { templateName: "other", lineNumber: 1 },
+        { templateName: "base", lineNumber: 1 },
+        { templateName: "base", lineNumber: 1 },
+      ],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      expectedFilters,
+      expectedTags,
+    );
   });
 
   test("analyze recursive extends", async () => {
@@ -1012,7 +1567,27 @@ describe("static template analysis", () => {
       foo: [{ templateName: "base", lineNumber: 1 }],
       "block.super": [{ templateName: "some", lineNumber: 1 }],
     };
+    const expectedFilters: VariableRefs = {
+      upcase: [{ templateName: "base", lineNumber: 1 }],
+    };
+    const expectedTags: VariableRefs = {
+      extends: [{ templateName: "some", lineNumber: 1 }],
+      block: [
+        { templateName: "some", lineNumber: 1 },
+        { templateName: "base", lineNumber: 1 },
+      ],
+    };
 
-    await _test(template, expectedVariables, expectedLocals, expectedGlobals);
+    await _test(
+      template,
+      expectedVariables,
+      expectedLocals,
+      expectedGlobals,
+      undefined,
+      undefined,
+      undefined,
+      expectedFilters,
+      expectedTags,
+    );
   });
 });


### PR DESCRIPTION
This pull requests adds filter and tag usage counts to the result of `Template.analyze()`. Closes #11.