### PR TITLE
fix: compare strings with all comparison operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # LiquidScript Change Log
 
+## Version 1.8.2 (unreleased)
+
+**Fixes**
+
+- Fixed comparison of strings in logical expressions. Previously we only supported comparing strings for equality with `==` and `!=`, now we support `<`, `>`, `<=` and `>=` too.
+
+
 ## Version 1.8.1
 
 **Fixes**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liquidscript",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "author": "James",
   "license": "MIT",
   "homepage": "https://jg-rp.github.io/liquidscript/",

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,17 @@ import { isLiquidStringable, toLiquidString } from "./drop";
 import { isNumberT, NumberT } from "./number";
 import { Undefined } from "./undefined";
 
+
+/**
+ * A type predicate for the primitive boolean.
+ * @param value - Any value
+ * @returns `true` if the value is a primitive boolean.
+ */
+export function isBoolean(value: unknown): value is boolean {
+  return typeof value == "boolean";
+}
+
+
 /**
  * A type predicate for the primitive string.
  * @param value - Any value

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,6 @@ import { isLiquidStringable, toLiquidString } from "./drop";
 import { isNumberT, NumberT } from "./number";
 import { Undefined } from "./undefined";
 
-
 /**
  * A type predicate for the primitive boolean.
  * @param value - Any value
@@ -11,7 +10,6 @@ import { Undefined } from "./undefined";
 export function isBoolean(value: unknown): value is boolean {
   return typeof value == "boolean";
 }
-
 
 /**
  * A type predicate for the primitive string.

--- a/tests/golden/golden_liquid.json
+++ b/tests/golden/golden_liquid.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.20.0",
+    "version": "0.22.0",
     "test_groups": [
         {
             "name": "liquid.golden.abs_filter",
@@ -3998,6 +3998,78 @@
                     "context": {},
                     "partials": {},
                     "error": true,
+                    "strict": false
+                },
+                {
+                    "name": "string is greater than or equal to string",
+                    "template": "{% if 'abc' >= 'acb' %}true{% else %}false{% endif %}",
+                    "want": "false",
+                    "context": {},
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "string is greater than string",
+                    "template": "{% if 'abc' > 'acb' %}true{% else %}false{% endif %}",
+                    "want": "false",
+                    "context": {},
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "string is less than or equal to string",
+                    "template": "{% if 'abc' <= 'acb' %}true{% else %}false{% endif %}",
+                    "want": "true",
+                    "context": {},
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "string is less than string",
+                    "template": "{% if 'abc' < 'acb' %}true{% else %}false{% endif %}",
+                    "want": "true",
+                    "context": {},
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "string is not greater than or equal to string",
+                    "template": "{% if 'bbb' >= 'aaa' %}true{% else %}false{% endif %}",
+                    "want": "true",
+                    "context": {},
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "string is not greater than string",
+                    "template": "{% if 'bbb' > 'aaa' %}true{% else %}false{% endif %}",
+                    "want": "true",
+                    "context": {},
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "string is not less than or equal to string",
+                    "template": "{% if 'bbb' <= 'aaa' %}true{% else %}false{% endif %}",
+                    "want": "false",
+                    "context": {},
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "string is not less than string",
+                    "template": "{% if 'bbb' < 'aaa' %}true{% else %}false{% endif %}",
+                    "want": "false",
+                    "context": {},
+                    "partials": {},
+                    "error": false,
                     "strict": false
                 },
                 {


### PR DESCRIPTION
Allow strings to be compared using `<`, `>`, `<=` and `>=`.